### PR TITLE
revert fuse bump

### DIFF
--- a/org.cryptomator.Cryptomator.yaml
+++ b/org.cryptomator.Cryptomator.yaml
@@ -51,12 +51,12 @@ modules:
       - -Dudevrulesdir=/tmp/
     sources:
       - type: archive
-        url: https://github.com/libfuse/libfuse/releases/download/fuse-3.15.1/fuse-3.15.1.tar.gz
-        sha256: 13ef77cda531a21c2131f9576042970e98035c0a5f019abf661506efd2d38a4e
+        url: https://github.com/libfuse/libfuse/releases/download/fuse-3.14.1/fuse-3.14.1.tar.xz
+        sha256: 126919d72b46b3e0eb58a9c6933a2a50c36f2ea69f61fe9e78bdba9f463ffa20
         x-checker-data:
           type: anitya
           project-id: 861
-          url-template: https://github.com/libfuse/libfuse/releases/download/fuse-$version/fuse-$version.tar.gz
+          url-template: https://github.com/libfuse/libfuse/releases/download/fuse-$version/fuse-$version.tar.xz
           versions: {<: '4.0'}
   - name: host-command-wrapper
     buildsystem: simple

--- a/org.cryptomator.Cryptomator.yaml
+++ b/org.cryptomator.Cryptomator.yaml
@@ -56,7 +56,7 @@ modules:
         x-checker-data:
           type: anitya
           project-id: 861
-          url-template: https://github.com/libfuse/libfuse/releases/download/fuse-$version/fuse-$version.tar.xz
+          url-template: https://github.com/libfuse/libfuse/releases/download/fuse-$version/fuse-$version.tar.gz
           versions: {<: '4.0'}
   - name: host-command-wrapper
     buildsystem: simple


### PR DESCRIPTION
Seems like flathub directly publishes an package update as soon as a new commit is pushed to master.

After merging https://github.com/flathub/org.cryptomator.Cryptomator/pull/43 and the above mentioned update mechanism, users reported to be unable to unlock their vaults. We have to revert this.