### PR TITLE
Drop org.kde.* own-name

### DIFF
--- a/org.cryptomator.Cryptomator.yaml
+++ b/org.cryptomator.Cryptomator.yaml
@@ -40,8 +40,6 @@ finish-args:
   - --talk-name=org.ayatana
   # Allow access to appindicator icons on KDE
   - --talk-name=org.kde.StatusNotifierWatcher
-  # Required for tray icons on KDE
-  - --own-name=org.kde.*
 cleanup:
   - /include
   - /lib/pkgconfig


### PR DESCRIPTION
This is no longer required with any supported runtimes

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement

https://github.com/flathub/flatpak-builder-lint/issues/66