### PR TITLE
Update freedesktop runtime to latest

### DIFF
--- a/org.cryptomator.Cryptomator.yaml
+++ b/org.cryptomator.Cryptomator.yaml
@@ -1,7 +1,7 @@
 app-id: org.cryptomator.Cryptomator
 command: cryptomator
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 separate-locales: false
 finish-args:


### PR DESCRIPTION
Since 23.08 runtime was released a long ago it would be a good time to update to it like most applications in flatpak.