### PR TITLE
Release 1.14.0

### DIFF
--- a/maven-dependencies-aarch64.yaml
+++ b/maven-dependencies-aarch64.yaml
@@ -1,30 +1,30 @@
 - type: file
-  dest: .m2/repository/org/openjfx/javafx-base/22.0.1
-  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-base/22.0.1/javafx-base-22.0.1-linux-aarch64.jar
-  sha1: dc98243251b8f73238e7dabf9effb77a75b06fc6
+  dest: .m2/repository/org/openjfx/javafx-base/22.0.2
+  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-base/22.0.2/javafx-base-22.0.2-linux-aarch64.jar
+  sha1: 87652b5069e97b488058450586ba29c7acf6208a
   only-arches:
     - aarch64
 - type: file
-  dest: .m2/repository/org/openjfx/javafx-controls/22.0.1
-  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-controls/22.0.1/javafx-controls-22.0.1-linux-aarch64.jar
-  sha1: 18ba15bcf8d7afb9f39fb4714f4986e5d9c90176
+  dest: .m2/repository/org/openjfx/javafx-controls/22.0.2
+  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-controls/22.0.2/javafx-controls-22.0.2-linux-aarch64.jar
+  sha1: 379031448fffd870bc2d36a2898702d7c642ddc3
   only-arches:
     - aarch64
 - type: file
-  dest: .m2/repository/org/openjfx/javafx-fxml/22.0.1
-  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-fxml/22.0.1/javafx-fxml-22.0.1-linux-aarch64.jar
-  sha1: c4f18553a33dfef4fae65732e44c5a199b5a3ebd
+  dest: .m2/repository/org/openjfx/javafx-fxml/22.0.2
+  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-fxml/22.0.2/javafx-fxml-22.0.2-linux-aarch64.jar
+  sha1: 2235e2d20c7616ddb4015bc58a32fbd564714f48
   only-arches:
     - aarch64
 - type: file
-  dest: .m2/repository/org/openjfx/javafx-graphics/22.0.1
-  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-graphics/22.0.1/javafx-graphics-22.0.1-linux-aarch64.jar
-  sha1: 277b402c5beae17b975b63f3cf142ac0de441f5f
+  dest: .m2/repository/org/openjfx/javafx-graphics/22.0.2
+  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-graphics/22.0.2/javafx-graphics-22.0.2-linux-aarch64.jar
+  sha1: 4298fee56400e286cbb7282594fd4c5f79104da3
   only-arches:
     - aarch64
 - type: file
-  dest: .m2/repository/org/openjfx/javafx-swing/22.0.1
-  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-swing/22.0.1/javafx-swing-22.0.1-linux-aarch64.jar
-  sha1: f7f34073d69d5d5a176e2a82ec947b9a50a0d56d
+  dest: .m2/repository/org/openjfx/javafx-swing/22.0.2
+  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-swing/22.0.2/javafx-swing-22.0.2-linux-aarch64.jar
+  sha1: 4c7dc7e14b8f16dadb4d4daa802ca77afeab5ef2
   only-arches:
     - aarch64

--- a/maven-dependencies-x86_64.yaml
+++ b/maven-dependencies-x86_64.yaml
@@ -1,30 +1,30 @@
 - type: file
-  dest: .m2/repository/org/openjfx/javafx-base/22.0.1
-  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-base/22.0.1/javafx-base-22.0.1-linux.jar
-  sha1: 8c6b06cb5c235c9c863c2197ca29a3217eb7067d
+  dest: .m2/repository/org/openjfx/javafx-base/22.0.2
+  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-base/22.0.2/javafx-base-22.0.2-linux.jar
+  sha1: 
   only-arches:
-  - x86_64
+    - x86_64
 - type: file
-  dest: .m2/repository/org/openjfx/javafx-controls/22.0.1
-  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-controls/22.0.1/javafx-controls-22.0.1-linux.jar
-  sha1: 86075210c7f34de1430eb393b921fd0f5637695a
+  dest: .m2/repository/org/openjfx/javafx-controls/22.0.2
+  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-controls/22.0.2/javafx-controls-22.0.2-linux.jar
+  sha1: 02849d310eaee4c2fb2c4e0078f01be38ed27d96
   only-arches:
-  - x86_64
+    - x86_64
 - type: file
-  dest: .m2/repository/org/openjfx/javafx-fxml/22.0.1
-  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-fxml/22.0.1/javafx-fxml-22.0.1-linux.jar
-  sha1: 1901f3c5b968e32cbf8e256cfe2a599d13062506
+  dest: .m2/repository/org/openjfx/javafx-fxml/22.0.2
+  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-fxml/22.0.2/javafx-fxml-22.0.2-linux.jar
+  sha1: 0afee1498e40790119a6496cb5a09943f64dcde5
   only-arches:
-  - x86_64
+    - x86_64
 - type: file
-  dest: .m2/repository/org/openjfx/javafx-graphics/22.0.1
-  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-graphics/22.0.1/javafx-graphics-22.0.1-linux.jar
-  sha1: c4e6fff7996a4ddd5e1736f4dafca451dbe28b6c
+  dest: .m2/repository/org/openjfx/javafx-graphics/22.0.2
+  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-graphics/22.0.2/javafx-graphics-22.0.2-linux.jar
+  sha1: e2ce99c2c94ed0f8c591a8d6e66bc99c2bfc72be
   only-arches:
-  - x86_64
+    - x86_64
 - type: file
-  dest: .m2/repository/org/openjfx/javafx-swing/22.0.1
-  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-swing/22.0.1/javafx-swing-22.0.1-linux.jar
-  sha1: 540c35c41f6229f78faa47f80f7d531f68c26b71
+  dest: .m2/repository/org/openjfx/javafx-swing/22.0.2
+  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-swing/22.0.2/javafx-swing-22.0.2-linux.jar
+  sha1: cf2558647a682d4184cc792807f3c5e1dbb35b50
   only-arches:
-  - x86_64
+    - x86_64

--- a/maven-dependencies-x86_64.yaml
+++ b/maven-dependencies-x86_64.yaml
@@ -1,7 +1,7 @@
 - type: file
   dest: .m2/repository/org/openjfx/javafx-base/22.0.2
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-base/22.0.2/javafx-base-22.0.2-linux.jar
-  sha1: 
+  sha1: 0c831bf8045cac41e9501454e658e61a1bdc1f3e
   only-arches:
     - x86_64
 - type: file

--- a/maven-dependencies.yaml
+++ b/maven-dependencies.yaml
@@ -2279,6 +2279,14 @@
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-xml/3.0.0/plexus-xml-3.0.0.pom
   sha1: f94a34d43206e704670533b74feb981b8de56640
 - type: file
+  dest: .m2/repository/org/cryptomator/cryptofs/2.7.0
+  url: https://repo.maven.apache.org/maven2/org/cryptomator/cryptofs/2.7.0/cryptofs-2.7.0.jar
+  sha1: 9fac6d1c83510d68ae7e63ed8ffb6140b978eed1
+- type: file
+  dest: .m2/repository/org/cryptomator/cryptofs/2.7.0
+  url: https://repo.maven.apache.org/maven2/org/cryptomator/cryptofs/2.7.0/cryptofs-2.7.0.pom
+  sha1: 209625ffce16d5923b913df6485a140ec9953d6f
+- type: file
   dest: .m2/repository/org/cryptomator/cryptofs/2.7.0-beta1
   url: https://repo.maven.apache.org/maven2/org/cryptomator/cryptofs/2.7.0-beta1/cryptofs-2.7.0-beta1.jar
   sha1: cf9c741a1370d5f638cd5915d0858b7e393476ef
@@ -2311,6 +2319,14 @@
   url: https://repo.maven.apache.org/maven2/org/cryptomator/integrations-api/1.3.1/integrations-api-1.3.1.pom
   sha1: de2f2d7e97eb62906326d97e03cb28769a1332cc
 - type: file
+  dest: .m2/repository/org/cryptomator/integrations-api/1.4.0
+  url: https://repo.maven.apache.org/maven2/org/cryptomator/integrations-api/1.4.0/integrations-api-1.4.0.jar
+  sha1: f3756fb181d5d4795dd4584b013fd6e19e528522
+- type: file
+  dest: .m2/repository/org/cryptomator/integrations-api/1.4.0
+  url: https://repo.maven.apache.org/maven2/org/cryptomator/integrations-api/1.4.0/integrations-api-1.4.0.pom
+  sha1: fed4311c5004ecd8977fd8e92f55aba21193bc23
+- type: file
   dest: .m2/repository/org/cryptomator/integrations-api/1.4.0-beta2
   url: https://repo.maven.apache.org/maven2/org/cryptomator/integrations-api/1.4.0-beta2/integrations-api-1.4.0-beta2.jar
   sha1: 75384c1f2821624a4bb9da99bb40370e37334d5b
@@ -2318,6 +2334,14 @@
   dest: .m2/repository/org/cryptomator/integrations-api/1.4.0-beta2
   url: https://repo.maven.apache.org/maven2/org/cryptomator/integrations-api/1.4.0-beta2/integrations-api-1.4.0-beta2.pom
   sha1: 0dcae551cbbef14b2fee6766a922fb8bf2e21037
+- type: file
+  dest: .m2/repository/org/cryptomator/integrations-linux/1.5.0
+  url: https://repo.maven.apache.org/maven2/org/cryptomator/integrations-linux/1.5.0/integrations-linux-1.5.0.jar
+  sha1: 49f99dd1ef0442bb073f6c17ac161be682aa8421
+- type: file
+  dest: .m2/repository/org/cryptomator/integrations-linux/1.5.0
+  url: https://repo.maven.apache.org/maven2/org/cryptomator/integrations-linux/1.5.0/integrations-linux-1.5.0.pom
+  sha1: a79e048528d62f9afaf603bb1b5586ca1f133d57
 - type: file
   dest: .m2/repository/org/cryptomator/integrations-linux/1.5.0-beta4
   url: https://repo.maven.apache.org/maven2/org/cryptomator/integrations-linux/1.5.0-beta4/integrations-linux-1.5.0-beta4.jar

--- a/maven-dependencies.yaml
+++ b/maven-dependencies.yaml
@@ -35,25 +35,25 @@
   url: https://repo.maven.apache.org/maven2/avalon-framework/avalon-framework/4.1.3/avalon-framework-4.1.3.pom
   sha1: 853c9df18e44caf0bab1eab8be0d482f9ec9bcd7
 - type: file
-  dest: .m2/repository/ch/qos/logback/logback-classic/1.5.6
-  url: https://repo.maven.apache.org/maven2/ch/qos/logback/logback-classic/1.5.6/logback-classic-1.5.6.jar
-  sha1: afc75d260d838a3bddfb8f207c2805ed7d1b34f9
+  dest: .m2/repository/ch/qos/logback/logback-classic/1.5.7
+  url: https://repo.maven.apache.org/maven2/ch/qos/logback/logback-classic/1.5.7/logback-classic-1.5.7.jar
+  sha1: ad4ff8ca015737ade8e8a9de07de565c423e5b7a
 - type: file
-  dest: .m2/repository/ch/qos/logback/logback-classic/1.5.6
-  url: https://repo.maven.apache.org/maven2/ch/qos/logback/logback-classic/1.5.6/logback-classic-1.5.6.pom
-  sha1: c36ed6ab109f34e3340ef2bb7a5faac267019f8c
+  dest: .m2/repository/ch/qos/logback/logback-classic/1.5.7
+  url: https://repo.maven.apache.org/maven2/ch/qos/logback/logback-classic/1.5.7/logback-classic-1.5.7.pom
+  sha1: 0bb8698aefe1f5a0331f9de070571bf78babcb8b
 - type: file
-  dest: .m2/repository/ch/qos/logback/logback-core/1.5.6
-  url: https://repo.maven.apache.org/maven2/ch/qos/logback/logback-core/1.5.6/logback-core-1.5.6.jar
-  sha1: 41cbe874701200c5624c19e0ab50d1b88dfcc77d
+  dest: .m2/repository/ch/qos/logback/logback-core/1.5.7
+  url: https://repo.maven.apache.org/maven2/ch/qos/logback/logback-core/1.5.7/logback-core-1.5.7.jar
+  sha1: ba0d0cbac3f21abd28faed3b4931d5b49cc5887e
 - type: file
-  dest: .m2/repository/ch/qos/logback/logback-core/1.5.6
-  url: https://repo.maven.apache.org/maven2/ch/qos/logback/logback-core/1.5.6/logback-core-1.5.6.pom
-  sha1: ce2b2c0de2d0c656ebccdad3d49b601293f77287
+  dest: .m2/repository/ch/qos/logback/logback-core/1.5.7
+  url: https://repo.maven.apache.org/maven2/ch/qos/logback/logback-core/1.5.7/logback-core-1.5.7.pom
+  sha1: e2878763104086374dc8d02a7a3bdc498ac490b7
 - type: file
-  dest: .m2/repository/ch/qos/logback/logback-parent/1.5.6
-  url: https://repo.maven.apache.org/maven2/ch/qos/logback/logback-parent/1.5.6/logback-parent-1.5.6.pom
-  sha1: c76cf268188662f3d4dd0399a6ddfee0c47fa7d4
+  dest: .m2/repository/ch/qos/logback/logback-parent/1.5.7
+  url: https://repo.maven.apache.org/maven2/ch/qos/logback/logback-parent/1.5.7/logback-parent-1.5.7.pom
+  sha1: 529fac6efc126cf49f949ef314b0effe346a1b7b
 - type: file
   dest: .m2/repository/com/auth0/java-jwt/4.4.0
   url: https://repo.maven.apache.org/maven2/com/auth0/java-jwt/4.4.0/java-jwt-4.4.0.jar
@@ -67,53 +67,53 @@
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.14.2/jackson-annotations-2.14.2.pom
   sha1: 31ae3aee07a17dc4323941f6a76c6d22ef09c501
 - type: file
-  dest: .m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.17.1
-  url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.17.1/jackson-annotations-2.17.1.jar
-  sha1: fca7ef6192c9ad05d07bc50da991bf937a84af3a
+  dest: .m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.17.2
+  url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.17.2/jackson-annotations-2.17.2.jar
+  sha1: 147b7b9412ffff24339f8aba080b292448e08698
 - type: file
-  dest: .m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.17.1
-  url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.17.1/jackson-annotations-2.17.1.pom
-  sha1: 186c3704ed2d09c8870722223a44e7b221da9a5a
+  dest: .m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.17.2
+  url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.17.2/jackson-annotations-2.17.2.pom
+  sha1: 742d1e93e17a0ee2e37403439cdd80678ceedccd
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/core/jackson-core/2.14.2
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.14.2/jackson-core-2.14.2.pom
   sha1: 76bac750b8718e4303ab6ea2742aab1422d3e8b9
 - type: file
-  dest: .m2/repository/com/fasterxml/jackson/core/jackson-core/2.17.1
-  url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.17.1/jackson-core-2.17.1.jar
-  sha1: 5e52a11644cd59a28ef79f02bddc2cc3bab45edb
+  dest: .m2/repository/com/fasterxml/jackson/core/jackson-core/2.17.2
+  url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.17.2/jackson-core-2.17.2.jar
+  sha1: 969a35cb35c86512acbadcdbbbfb044c877db814
 - type: file
-  dest: .m2/repository/com/fasterxml/jackson/core/jackson-core/2.17.1
-  url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.17.1/jackson-core-2.17.1.pom
-  sha1: 22a579663e24a696b98a352eb423ca393dc1a4bd
+  dest: .m2/repository/com/fasterxml/jackson/core/jackson-core/2.17.2
+  url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.17.2/jackson-core-2.17.2.pom
+  sha1: 56ebdda21a42d361ae3811b39a7053fc305d584e
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/core/jackson-databind/2.14.2
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.14.2/jackson-databind-2.14.2.pom
   sha1: a16354be031c98c5eee8862e9974bb4f49be1f13
 - type: file
-  dest: .m2/repository/com/fasterxml/jackson/core/jackson-databind/2.17.1
-  url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.17.1/jackson-databind-2.17.1.jar
-  sha1: 0524dcbcccdde7d45a679dfc333e4763feb09079
+  dest: .m2/repository/com/fasterxml/jackson/core/jackson-databind/2.17.2
+  url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.17.2/jackson-databind-2.17.2.jar
+  sha1: e6deb029e5901e027c129341fac39e515066b68c
 - type: file
-  dest: .m2/repository/com/fasterxml/jackson/core/jackson-databind/2.17.1
-  url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.17.1/jackson-databind-2.17.1.pom
-  sha1: 6948da5a23ce75d431982d8228b67299b57be315
+  dest: .m2/repository/com/fasterxml/jackson/core/jackson-databind/2.17.2
+  url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.17.2/jackson-databind-2.17.2.pom
+  sha1: 0091859e6b26ea19c60a35f49993f58c1c15d3bd
 - type: file
-  dest: .m2/repository/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.17.1
-  url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.17.1/jackson-datatype-jsr310-2.17.1.jar
-  sha1: 0969b0c3cb8c75d759e9a6c585c44c9b9f3a4f75
+  dest: .m2/repository/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.17.2
+  url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.17.2/jackson-datatype-jsr310-2.17.2.jar
+  sha1: 267b85e9ba2892a37be6d80aa9ca1438a0d8c210
 - type: file
-  dest: .m2/repository/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.17.1
-  url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.17.1/jackson-datatype-jsr310-2.17.1.pom
-  sha1: 1b6da32820fa6fa8105801399e47549be38c8c2d
+  dest: .m2/repository/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.17.2
+  url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.17.2/jackson-datatype-jsr310-2.17.2.pom
+  sha1: e995fe7fe2caa0629a2110c99aa7a861bf818ff6
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/jackson-base/2.14.2
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-base/2.14.2/jackson-base-2.14.2.pom
   sha1: 9d05485c7ec37cd4e97d1ea00b200d879bec5913
 - type: file
-  dest: .m2/repository/com/fasterxml/jackson/jackson-base/2.17.1
-  url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-base/2.17.1/jackson-base-2.17.1.pom
-  sha1: f5b8cfce0e5562b14ac36020b46ec3bcd8f2d990
+  dest: .m2/repository/com/fasterxml/jackson/jackson-base/2.17.2
+  url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-base/2.17.2/jackson-base-2.17.2.pom
+  sha1: 3264a20cda3d7b01815fb83a59cd124c25689f02
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/jackson-bom/2.14.2
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-bom/2.14.2/jackson-bom-2.14.2.pom
@@ -127,9 +127,9 @@
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-bom/2.16.1/jackson-bom-2.16.1.pom
   sha1: 0e56871cbeb604dfdce9ffac8ce705d049f478cf
 - type: file
-  dest: .m2/repository/com/fasterxml/jackson/jackson-bom/2.17.1
-  url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-bom/2.17.1/jackson-bom-2.17.1.pom
-  sha1: 3bd0a8fe4faa6434ff0109e330349fd8cff0967f
+  dest: .m2/repository/com/fasterxml/jackson/jackson-bom/2.17.2
+  url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-bom/2.17.2/jackson-bom-2.17.2.pom
+  sha1: e772457e00739867a8f382ef0a8c4dcb03558772
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/jackson-parent/2.14
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-parent/2.14/jackson-parent-2.14.pom
@@ -147,9 +147,9 @@
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-parent/2.17/jackson-parent-2.17.pom
   sha1: df97fedb1aae67d608a69fa9262410247f3d31af
 - type: file
-  dest: .m2/repository/com/fasterxml/jackson/module/jackson-modules-java8/2.17.1
-  url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/module/jackson-modules-java8/2.17.1/jackson-modules-java8-2.17.1.pom
-  sha1: 885dc6a84da22a87b69910418e022cd33073b1e1
+  dest: .m2/repository/com/fasterxml/jackson/module/jackson-modules-java8/2.17.2
+  url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/module/jackson-modules-java8/2.17.2/jackson-modules-java8-2.17.2.pom
+  sha1: 5ec9cc6d08c9b7a9211d6319fad9a5a3d2fafc36
 - type: file
   dest: .m2/repository/com/fasterxml/oss-parent/48
   url: https://repo.maven.apache.org/maven2/com/fasterxml/oss-parent/48/oss-parent-48.pom
@@ -243,10 +243,6 @@
   url: https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.pom
   sha1: 8d93cdf4d84d7e1de736df607945c6df0730a10f
 - type: file
-  dest: .m2/repository/com/google/code/gson/gson/2.8.9
-  url: https://repo.maven.apache.org/maven2/com/google/code/gson/gson/2.8.9/gson-2.8.9.pom
-  sha1: e40b03e4cc2b52efb19af75c07596e9d15a52d82
-- type: file
   dest: .m2/repository/com/google/code/gson/gson/2.10.1
   url: https://repo.maven.apache.org/maven2/com/google/code/gson/gson/2.10.1/gson-2.10.1.jar
   sha1: b3add478d4382b78ea20b1671390a858002feb6c
@@ -255,10 +251,6 @@
   url: https://repo.maven.apache.org/maven2/com/google/code/gson/gson/2.10.1/gson-2.10.1.pom
   sha1: ce159faf33c1e665e1f3a785a5d678a2b20151bc
 - type: file
-  dest: .m2/repository/com/google/code/gson/gson-parent/2.8.9
-  url: https://repo.maven.apache.org/maven2/com/google/code/gson/gson-parent/2.8.9/gson-parent-2.8.9.pom
-  sha1: 0c3fdad2fa3239f928ad9c77a9f9c9379f6bde7a
-- type: file
   dest: .m2/repository/com/google/code/gson/gson-parent/2.10.1
   url: https://repo.maven.apache.org/maven2/com/google/code/gson/gson-parent/2.10.1/gson-parent-2.10.1.pom
   sha1: 67ea6db077285dc50a9b0a627763764f0ef4a770
@@ -266,10 +258,6 @@
   dest: .m2/repository/com/google/collections/google-collections/1.0
   url: https://repo.maven.apache.org/maven2/com/google/collections/google-collections/1.0/google-collections-1.0.pom
   sha1: 292197f3cb1ebc0dd03e20897e4250b265177286
-- type: file
-  dest: .m2/repository/com/google/dagger/dagger/2.49
-  url: https://repo.maven.apache.org/maven2/com/google/dagger/dagger/2.49/dagger-2.49.pom
-  sha1: 837e0b3ab124ba4f126a7f88d852040974b917ad
 - type: file
   dest: .m2/repository/com/google/dagger/dagger/2.51.1
   url: https://repo.maven.apache.org/maven2/com/google/dagger/dagger/2.51.1/dagger-2.51.1.jar
@@ -307,17 +295,9 @@
   url: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.0.18/error_prone_annotations-2.0.18.pom
   sha1: 8e0351439081cc11563b09019302926addadaa25
 - type: file
-  dest: .m2/repository/com/google/errorprone/error_prone_annotations/2.7.1
-  url: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.7.1/error_prone_annotations-2.7.1.pom
-  sha1: 0b0fa22131b64b3985fba347927252af21898984
-- type: file
   dest: .m2/repository/com/google/errorprone/error_prone_annotations/2.18.0
   url: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.18.0/error_prone_annotations-2.18.0.pom
   sha1: 6d7bbfd3d7567e4c18e981a675ecda707e8a2db1
-- type: file
-  dest: .m2/repository/com/google/errorprone/error_prone_annotations/2.21.1
-  url: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.21.1/error_prone_annotations-2.21.1.pom
-  sha1: e3d7e7e5c6e7b24256bd55642344a8d99b64e599
 - type: file
   dest: .m2/repository/com/google/errorprone/error_prone_annotations/2.23.0
   url: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.23.0/error_prone_annotations-2.23.0.jar
@@ -335,17 +315,9 @@
   url: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.0.18/error_prone_parent-2.0.18.pom
   sha1: 16ffdb67ed91d9d87a943a3127da3900d83cc81d
 - type: file
-  dest: .m2/repository/com/google/errorprone/error_prone_parent/2.7.1
-  url: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.7.1/error_prone_parent-2.7.1.pom
-  sha1: cca3ba79de44febe5a196510393e1011bd554e0b
-- type: file
   dest: .m2/repository/com/google/errorprone/error_prone_parent/2.18.0
   url: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.18.0/error_prone_parent-2.18.0.pom
   sha1: b1779a677965027cd2a3de91e61a80102086bb30
-- type: file
-  dest: .m2/repository/com/google/errorprone/error_prone_parent/2.21.1
-  url: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.21.1/error_prone_parent-2.21.1.pom
-  sha1: e5a62220a9c871cb1283dde6e52b7f1f21c84207
 - type: file
   dest: .m2/repository/com/google/errorprone/error_prone_parent/2.23.0
   url: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.23.0/error_prone_parent-2.23.0.pom
@@ -403,17 +375,9 @@
   url: https://repo.maven.apache.org/maven2/com/google/guava/guava/22.0/guava-22.0.pom
   sha1: b87878db57d5cfc2ca7d3972cc8f7486bf02fbca
 - type: file
-  dest: .m2/repository/com/google/guava/guava/31.0.1-jre
-  url: https://repo.maven.apache.org/maven2/com/google/guava/guava/31.0.1-jre/guava-31.0.1-jre.pom
-  sha1: d0ec1628dcc04e4835721416103672384ea3136f
-- type: file
   dest: .m2/repository/com/google/guava/guava/32.1.1-jre
   url: https://repo.maven.apache.org/maven2/com/google/guava/guava/32.1.1-jre/guava-32.1.1-jre.pom
   sha1: 0e5cbc6d9046ce986b121a842f8d30ee6d81a900
-- type: file
-  dest: .m2/repository/com/google/guava/guava/32.1.3-jre
-  url: https://repo.maven.apache.org/maven2/com/google/guava/guava/32.1.3-jre/guava-32.1.3-jre.pom
-  sha1: 698deeca13a1dc49e069b8a7e11d8cc2ff6a8cf9
 - type: file
   dest: .m2/repository/com/google/guava/guava/33.0.0-jre
   url: https://repo.maven.apache.org/maven2/com/google/guava/guava/33.0.0-jre/guava-33.0.0-jre.jar
@@ -428,12 +392,16 @@
   sha1: ff9e5899929c5ff0de96f6d9a49359ecc088f756
 - type: file
   dest: .m2/repository/com/google/guava/guava/33.2.1-jre
-  url: https://repo.maven.apache.org/maven2/com/google/guava/guava/33.2.1-jre/guava-33.2.1-jre.jar
-  sha1: 818e780da2c66c63bbb6480fef1f3855eeafa3e4
-- type: file
-  dest: .m2/repository/com/google/guava/guava/33.2.1-jre
   url: https://repo.maven.apache.org/maven2/com/google/guava/guava/33.2.1-jre/guava-33.2.1-jre.pom
   sha1: 5f72123f1bb7d99af8b4a67745fb8309b73a6294
+- type: file
+  dest: .m2/repository/com/google/guava/guava/33.3.0-jre
+  url: https://repo.maven.apache.org/maven2/com/google/guava/guava/33.3.0-jre/guava-33.3.0-jre.jar
+  sha1: 13b4d0924e6023eda04b4c7aa83b32dfedf735a7
+- type: file
+  dest: .m2/repository/com/google/guava/guava/33.3.0-jre
+  url: https://repo.maven.apache.org/maven2/com/google/guava/guava/33.3.0-jre/guava-33.3.0-jre.pom
+  sha1: 7ccfd20558d84416c3c0385e569d116a45202269
 - type: file
   dest: .m2/repository/com/google/guava/guava-parent/10.0.1
   url: https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/10.0.1/guava-parent-10.0.1.pom
@@ -447,17 +415,9 @@
   url: https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/26.0-android/guava-parent-26.0-android.pom
   sha1: a2c0df489614352b7e8e503e274bd1dee5c42a64
 - type: file
-  dest: .m2/repository/com/google/guava/guava-parent/31.0.1-jre
-  url: https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/31.0.1-jre/guava-parent-31.0.1-jre.pom
-  sha1: eb78b5264bd92cca5655396c44420eef3ad3ec0f
-- type: file
   dest: .m2/repository/com/google/guava/guava-parent/32.1.1-jre
   url: https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/32.1.1-jre/guava-parent-32.1.1-jre.pom
   sha1: 01c4a3f0686592f40c1052b273c9b533f6a71e6d
-- type: file
-  dest: .m2/repository/com/google/guava/guava-parent/32.1.3-jre
-  url: https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/32.1.3-jre/guava-parent-32.1.3-jre.pom
-  sha1: 25e3a63dea904b6b1461cb6cbcf7e31bd211714e
 - type: file
   dest: .m2/repository/com/google/guava/guava-parent/33.0.0-jre
   url: https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/33.0.0-jre/guava-parent-33.0.0-jre.pom
@@ -471,6 +431,10 @@
   url: https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/33.2.1-jre/guava-parent-33.2.1-jre.pom
   sha1: fc55955fab23e86fad230acc81bf570deb5660bd
 - type: file
+  dest: .m2/repository/com/google/guava/guava-parent/33.3.0-jre
+  url: https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/33.3.0-jre/guava-parent-33.3.0-jre.pom
+  sha1: 24b614a34a06ced7c0fba8f4314c0e2d25bc75d6
+- type: file
   dest: .m2/repository/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava
   url: https://repo.maven.apache.org/maven2/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
   sha1: b421526c5f297295adef1c886e5246c39d4ac629
@@ -482,10 +446,6 @@
   dest: .m2/repository/com/google/j2objc/j2objc-annotations/1.1
   url: https://repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.pom
   sha1: b964a9414771661bdf35a3f10692a2fb0dd2c866
-- type: file
-  dest: .m2/repository/com/google/j2objc/j2objc-annotations/1.3
-  url: https://repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/1.3/j2objc-annotations-1.3.pom
-  sha1: 47e0dd93285dcc6b33181713bc7e8aed66742964
 - type: file
   dest: .m2/repository/com/google/j2objc/j2objc-annotations/2.8
   url: https://repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/2.8/j2objc-annotations-2.8.jar
@@ -835,13 +795,13 @@
   url: https://repo.maven.apache.org/maven2/logkit/logkit/1.0.1/logkit-1.0.1.pom
   sha1: ff3b4e6ced322bc8a21fa3aadfcf7f131a1ee08c
 - type: file
-  dest: .m2/repository/me/fabriciorby/maven-surefire-junit5-tree-reporter/1.2.1
-  url: https://repo.maven.apache.org/maven2/me/fabriciorby/maven-surefire-junit5-tree-reporter/1.2.1/maven-surefire-junit5-tree-reporter-1.2.1.jar
-  sha1: 795136d96c003b2f72ff79cea71224f54d06e727
+  dest: .m2/repository/me/fabriciorby/maven-surefire-junit5-tree-reporter/1.3.0
+  url: https://repo.maven.apache.org/maven2/me/fabriciorby/maven-surefire-junit5-tree-reporter/1.3.0/maven-surefire-junit5-tree-reporter-1.3.0.jar
+  sha1: f7f3dee6e89d2cb30e97146ef0688f2cff269633
 - type: file
-  dest: .m2/repository/me/fabriciorby/maven-surefire-junit5-tree-reporter/1.2.1
-  url: https://repo.maven.apache.org/maven2/me/fabriciorby/maven-surefire-junit5-tree-reporter/1.2.1/maven-surefire-junit5-tree-reporter-1.2.1.pom
-  sha1: c0f9812400b9cc09717aa4b2ccd488aeb193165e
+  dest: .m2/repository/me/fabriciorby/maven-surefire-junit5-tree-reporter/1.3.0
+  url: https://repo.maven.apache.org/maven2/me/fabriciorby/maven-surefire-junit5-tree-reporter/1.3.0/maven-surefire-junit5-tree-reporter-1.3.0.pom
+  sha1: 7181ad387b90548ef75a697693438f41e6ac0b50
 - type: file
   dest: .m2/repository/net/bytebuddy/byte-buddy/1.14.15
   url: https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy/1.14.15/byte-buddy-1.14.15.jar
@@ -939,10 +899,6 @@
   url: https://repo.maven.apache.org/maven2/org/apache/apache/26/apache-26.pom
   sha1: d05aaef85ff7d6ddf4e5c8770046c006cb66795a
 - type: file
-  dest: .m2/repository/org/apache/apache/27
-  url: https://repo.maven.apache.org/maven2/org/apache/apache/27/apache-27.pom
-  sha1: ea179482b464bfc8cac939c6d6e632b6a8e3316b
-- type: file
   dest: .m2/repository/org/apache/apache/29
   url: https://repo.maven.apache.org/maven2/org/apache/apache/29/apache-29.pom
   sha1: 57991491045c9a37a3113f24bf29a41a4ceb1459
@@ -958,6 +914,10 @@
   dest: .m2/repository/org/apache/apache/32
   url: https://repo.maven.apache.org/maven2/org/apache/apache/32/apache-32.pom
   sha1: 2e08f841a6fbc946452701faaf5e39a17ac97ef3
+- type: file
+  dest: .m2/repository/org/apache/apache/33
+  url: https://repo.maven.apache.org/maven2/org/apache/apache/33/apache-33.pom
+  sha1: f7b7b5a9e84395f17d7e6a136e5bfc4b9973566d
 - type: file
   dest: .m2/repository/org/apache/commons/commons-collections4/4.4
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-collections4/4.4/commons-collections4-4.4.jar
@@ -1026,6 +986,14 @@
   dest: .m2/repository/org/apache/commons/commons-lang3/3.14.0
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.14.0/commons-lang3-3.14.0.pom
   sha1: 063304d0daef2181ff359107bc29fb865a04d3cf
+- type: file
+  dest: .m2/repository/org/apache/commons/commons-lang3/3.16.0
+  url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.16.0/commons-lang3-3.16.0.jar
+  sha1: 3eb54effe40946dfb06dc5cd6c7ce4116cd51ea4
+- type: file
+  dest: .m2/repository/org/apache/commons/commons-lang3/3.16.0
+  url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.16.0/commons-lang3-3.16.0.pom
+  sha1: 48213bd4b10e67ea9a51e5fd5383f3cb0d473271
 - type: file
   dest: .m2/repository/org/apache/commons/commons-math3/3.6.1
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar
@@ -1102,6 +1070,10 @@
   dest: .m2/repository/org/apache/commons/commons-parent/69
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/69/commons-parent-69.pom
   sha1: 6ebeacd37818d945d96c06b44af10e050d2ef7c4
+- type: file
+  dest: .m2/repository/org/apache/commons/commons-parent/72
+  url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/72/commons-parent-72.pom
+  sha1: cdfbaff82e756be4cb74d3f09b8fbf8f6b06c79d
 - type: file
   dest: .m2/repository/org/apache/commons/commons-text/1.3
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.3/commons-text-1.3.jar
@@ -1515,10 +1487,6 @@
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/36/maven-parent-36.pom
   sha1: af78602525e1c7ac4575ef2e3059b7910bb79f3a
 - type: file
-  dest: .m2/repository/org/apache/maven/maven-parent/37
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/37/maven-parent-37.pom
-  sha1: 4dea31650e71386d7c41da8806ef4c87ef8de0b1
-- type: file
   dest: .m2/repository/org/apache/maven/maven-parent/39
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/39/maven-parent-39.pom
   sha1: 9b763d93ee3622181d8d39f62e8e995266c12362
@@ -1583,21 +1551,21 @@
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.13.0/maven-compiler-plugin-3.13.0.pom
   sha1: e4881f5e9859c3f8ba1ba094cf21bd911e7c5d73
 - type: file
-  dest: .m2/repository/org/apache/maven/plugins/maven-dependency-plugin/3.7.0
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-dependency-plugin/3.7.0/maven-dependency-plugin-3.7.0.jar
-  sha1: 320cfbc51fd155978c235fce6e7d9dad6c80bc84
+  dest: .m2/repository/org/apache/maven/plugins/maven-dependency-plugin/3.7.1
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-dependency-plugin/3.7.1/maven-dependency-plugin-3.7.1.jar
+  sha1: 39a9965632086fa976c27d4922d0fa42ab25f7eb
 - type: file
-  dest: .m2/repository/org/apache/maven/plugins/maven-dependency-plugin/3.7.0
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-dependency-plugin/3.7.0/maven-dependency-plugin-3.7.0.pom
-  sha1: e8c0bbc45a221e136418ca0868e4c994159c8ef5
+  dest: .m2/repository/org/apache/maven/plugins/maven-dependency-plugin/3.7.1
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-dependency-plugin/3.7.1/maven-dependency-plugin-3.7.1.pom
+  sha1: 96bf52d239009fb6d36bb20c7dcbda1feb13f82b
 - type: file
-  dest: .m2/repository/org/apache/maven/plugins/maven-jar-plugin/3.4.1
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/3.4.1/maven-jar-plugin-3.4.1.jar
-  sha1: 44be5e76ba16ce060eac02396299bc5dfe81d0eb
+  dest: .m2/repository/org/apache/maven/plugins/maven-jar-plugin/3.4.2
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/3.4.2/maven-jar-plugin-3.4.2.jar
+  sha1: 0a0a87aac2d20eb362d902d560294294fb26eacb
 - type: file
-  dest: .m2/repository/org/apache/maven/plugins/maven-jar-plugin/3.4.1
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/3.4.1/maven-jar-plugin-3.4.1.pom
-  sha1: f4be98b08ba44b43eb7b13dbddee45d0032b1665
+  dest: .m2/repository/org/apache/maven/plugins/maven-jar-plugin/3.4.2
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/3.4.2/maven-jar-plugin-3.4.2.pom
+  sha1: 388d7cde37747422363dced3f5326238a7a578af
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-plugins/35
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/35/maven-plugins-35.pom
@@ -1623,13 +1591,13 @@
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/3.3.1/maven-resources-plugin-3.3.1.pom
   sha1: 9966f75b0f17184e0a3b7716adcb2f6b753e3088
 - type: file
-  dest: .m2/repository/org/apache/maven/plugins/maven-surefire-plugin/3.3.0
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/3.3.0/maven-surefire-plugin-3.3.0.jar
-  sha1: f6b31ab2e6c97fd7c52484c4ed6c2c5a48be6a7a
+  dest: .m2/repository/org/apache/maven/plugins/maven-surefire-plugin/3.4.0
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/3.4.0/maven-surefire-plugin-3.4.0.jar
+  sha1: cbbeae3b48ba1ac58704e79cb90a8403607efa48
 - type: file
-  dest: .m2/repository/org/apache/maven/plugins/maven-surefire-plugin/3.3.0
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/3.3.0/maven-surefire-plugin-3.3.0.pom
-  sha1: cac6049da46428abad5ba2fbfd2859d016800a30
+  dest: .m2/repository/org/apache/maven/plugins/maven-surefire-plugin/3.4.0
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/3.4.0/maven-surefire-plugin-3.4.0.pom
+  sha1: 4b70e95dbddbe5f2d2f349eca141364c2b91a6d0
 - type: file
   dest: .m2/repository/org/apache/maven/reporting/maven-reporting-api/3.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/3.0/maven-reporting-api-3.0.pom
@@ -1703,14 +1671,6 @@
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.1.0/maven-common-artifact-filters-3.1.0.pom
   sha1: 2b2b1b986c2c758db97d6e6c399aab368e323f98
 - type: file
-  dest: .m2/repository/org/apache/maven/shared/maven-common-artifact-filters/3.3.2
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.3.2/maven-common-artifact-filters-3.3.2.jar
-  sha1: c1cb1bc78ae8c6a6e64da833d4a9afbda5e0834a
-- type: file
-  dest: .m2/repository/org/apache/maven/shared/maven-common-artifact-filters/3.3.2
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.3.2/maven-common-artifact-filters-3.3.2.pom
-  sha1: 52270cc2218ca35cba2b0828ec272f1d8506d408
-- type: file
   dest: .m2/repository/org/apache/maven/shared/maven-common-artifact-filters/3.4.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.4.0/maven-common-artifact-filters-3.4.0.jar
   sha1: 25855b1fa26fa5a1b387375de4b14ac39df23981
@@ -1767,10 +1727,6 @@
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/36/maven-shared-components-36.pom
   sha1: 0376c5365dff8496ca0185247296d760ee80dfec
 - type: file
-  dest: .m2/repository/org/apache/maven/shared/maven-shared-components/37
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/37/maven-shared-components-37.pom
-  sha1: c38a33f4773da60ee98a770e2c980586d62df432
-- type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-components/39
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/39/maven-shared-components-39.pom
   sha1: c6707d46530a62cdc0e6d9cf70061f80d002f862
@@ -1811,97 +1767,65 @@
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.4.2/maven-shared-utils-3.4.2.pom
   sha1: 78e0d256abbc6df63b2bb96493dd99daa29be63f
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/maven-surefire-common/3.1.0
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/3.1.0/maven-surefire-common-3.1.0.pom
-  sha1: b2303df2741f2ff86a193523e10359d486337c42
+  dest: .m2/repository/org/apache/maven/surefire/maven-surefire-common/3.4.0
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/3.4.0/maven-surefire-common-3.4.0.jar
+  sha1: b2164a10d3da5e5528229ecf54a953669da6d9cb
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/maven-surefire-common/3.3.0
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/3.3.0/maven-surefire-common-3.3.0.jar
-  sha1: 1c9b9a3fe2f1f5a1c1c7d1530e9ce00bf6da8258
+  dest: .m2/repository/org/apache/maven/surefire/maven-surefire-common/3.4.0
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/3.4.0/maven-surefire-common-3.4.0.pom
+  sha1: c40e2bb4510fab8e5714432a59176184374fe311
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/maven-surefire-common/3.3.0
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/3.3.0/maven-surefire-common-3.3.0.pom
-  sha1: c79cfa0569e9c4329d8a3d0cc367b270a12b9e25
+  dest: .m2/repository/org/apache/maven/surefire/surefire/3.4.0
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire/3.4.0/surefire-3.4.0.pom
+  sha1: 5418e8d72760d9ee02a1ed2e01e7dc21171117ea
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire/3.1.0
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire/3.1.0/surefire-3.1.0.pom
-  sha1: 327008127412b95017659bb38d08f31f0e1f7594
+  dest: .m2/repository/org/apache/maven/surefire/surefire-api/3.4.0
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/3.4.0/surefire-api-3.4.0.jar
+  sha1: d6845f8c35941f8b9f705fd43a22914fe50ef2a0
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire/3.3.0
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire/3.3.0/surefire-3.3.0.pom
-  sha1: 81c0e7616a688e985c7ac0236a44a1274ea76990
+  dest: .m2/repository/org/apache/maven/surefire/surefire-api/3.4.0
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/3.4.0/surefire-api-3.4.0.pom
+  sha1: 1a51e18af576135d663574c1bd225e5f86784f41
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-api/3.1.0
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/3.1.0/surefire-api-3.1.0.pom
-  sha1: 3ffaa6d7b6d4b5f7acfd662e5c145ad9488cdc16
+  dest: .m2/repository/org/apache/maven/surefire/surefire-booter/3.4.0
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/3.4.0/surefire-booter-3.4.0.jar
+  sha1: 7ba3385a0d7bae811c3931b65de1dc3611c67303
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-api/3.3.0
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/3.3.0/surefire-api-3.3.0.jar
-  sha1: 859aa0894fb0c1b5542f0a53b35406c8de38a2ad
+  dest: .m2/repository/org/apache/maven/surefire/surefire-booter/3.4.0
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/3.4.0/surefire-booter-3.4.0.pom
+  sha1: 704d7262dbc92cda9baedb3428e136b0a9adc403
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-api/3.3.0
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/3.3.0/surefire-api-3.3.0.pom
-  sha1: feefe61c7e8c8c81b9f32367e6e4e6891153bc9c
+  dest: .m2/repository/org/apache/maven/surefire/surefire-extensions-api/3.4.0
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-api/3.4.0/surefire-extensions-api-3.4.0.jar
+  sha1: c6ff414cf938cbbb12e334b468c0a5f94763547e
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-booter/3.1.0
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/3.1.0/surefire-booter-3.1.0.pom
-  sha1: 5147674985fe063661d3656fc471174e70076e52
+  dest: .m2/repository/org/apache/maven/surefire/surefire-extensions-api/3.4.0
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-api/3.4.0/surefire-extensions-api-3.4.0.pom
+  sha1: 66c3549c971705d517a848701531df28e6e4039f
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-booter/3.3.0
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/3.3.0/surefire-booter-3.3.0.jar
-  sha1: 7f9ea30b3ea472d040b187daedf85464c884cd58
+  dest: .m2/repository/org/apache/maven/surefire/surefire-extensions-spi/3.4.0
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-spi/3.4.0/surefire-extensions-spi-3.4.0.jar
+  sha1: 7bd182887e670944ce1a0eeaf5eee4288af57cec
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-booter/3.3.0
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/3.3.0/surefire-booter-3.3.0.pom
-  sha1: fb41be0426f1f595bf509377a17253a84094d5bc
+  dest: .m2/repository/org/apache/maven/surefire/surefire-extensions-spi/3.4.0
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-spi/3.4.0/surefire-extensions-spi-3.4.0.pom
+  sha1: 1fdaa2607e9172886630189c22ad24bc93cf1dc1
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-extensions-api/3.1.0
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-api/3.1.0/surefire-extensions-api-3.1.0.pom
-  sha1: 9384bab71e3cff5793a00f7591e5195a8e2a06bd
+  dest: .m2/repository/org/apache/maven/surefire/surefire-logger-api/3.4.0
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-logger-api/3.4.0/surefire-logger-api-3.4.0.jar
+  sha1: f76a61aa4d8cb7d51137a86791321b0dfde43b7b
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-extensions-api/3.3.0
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-api/3.3.0/surefire-extensions-api-3.3.0.jar
-  sha1: 33c90ce8ccd9942d29b2c05bc3a4db3d6d86548b
+  dest: .m2/repository/org/apache/maven/surefire/surefire-logger-api/3.4.0
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-logger-api/3.4.0/surefire-logger-api-3.4.0.pom
+  sha1: efa8502bf0ec64241cc183db0e3e94871213cfd6
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-extensions-api/3.3.0
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-api/3.3.0/surefire-extensions-api-3.3.0.pom
-  sha1: d27cabb19e3667176e933ee8c26332df6c30704a
+  dest: .m2/repository/org/apache/maven/surefire/surefire-shared-utils/3.4.0
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-shared-utils/3.4.0/surefire-shared-utils-3.4.0.jar
+  sha1: 9c966f238e3d93677091354ffa3071e2017798ca
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-extensions-spi/3.1.0
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-spi/3.1.0/surefire-extensions-spi-3.1.0.pom
-  sha1: 8743c8c5e1a9a9122f45103e02f7ff2ef60c3f00
-- type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-extensions-spi/3.3.0
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-spi/3.3.0/surefire-extensions-spi-3.3.0.jar
-  sha1: f838e72f423150d5429740946df609554ddd6447
-- type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-extensions-spi/3.3.0
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-spi/3.3.0/surefire-extensions-spi-3.3.0.pom
-  sha1: a25d5661c479d3c606145774e04fab3d5d0062e1
-- type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-logger-api/3.1.0
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-logger-api/3.1.0/surefire-logger-api-3.1.0.pom
-  sha1: 520cb704efe7a3d77d4ff48a01f55d734e3e65d9
-- type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-logger-api/3.3.0
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-logger-api/3.3.0/surefire-logger-api-3.3.0.jar
-  sha1: 260410a21ad54da23432bf16fc8397f2c972210a
-- type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-logger-api/3.3.0
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-logger-api/3.3.0/surefire-logger-api-3.3.0.pom
-  sha1: 2732a6f9c929391525643070b78a8b5d8a3dcf74
-- type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-shared-utils/3.1.0
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-shared-utils/3.1.0/surefire-shared-utils-3.1.0.pom
-  sha1: 8195ab552823cb911085389eb7c1dc2cbb6734f5
-- type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-shared-utils/3.3.0
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-shared-utils/3.3.0/surefire-shared-utils-3.3.0.jar
-  sha1: 9962d270d8d04da91e52b22591308aad5e9f43af
-- type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-shared-utils/3.3.0
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-shared-utils/3.3.0/surefire-shared-utils-3.3.0.pom
-  sha1: 3059dc43ed99a119cc0cc3e3f385a136bc5aae73
+  dest: .m2/repository/org/apache/maven/surefire/surefire-shared-utils/3.4.0
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-shared-utils/3.4.0/surefire-shared-utils-3.4.0.pom
+  sha1: 2e4040189c128136b4fb136faa6c50f7db43213e
 - type: file
   dest: .m2/repository/org/apache/poi/poi/5.2.5
   url: https://repo.maven.apache.org/maven2/org/apache/poi/poi/5.2.5/poi-5.2.5.jar
@@ -1983,17 +1907,9 @@
   url: https://repo.maven.apache.org/maven2/org/checkerframework/checker-compat-qual/2.5.5/checker-compat-qual-2.5.5.pom
   sha1: 493796785b3c508c4c25e539321218511bd1c1ae
 - type: file
-  dest: .m2/repository/org/checkerframework/checker-qual/3.12.0
-  url: https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.12.0/checker-qual-3.12.0.pom
-  sha1: fb8dca6f40fcb30f7b89de269940bf3316fb9845
-- type: file
   dest: .m2/repository/org/checkerframework/checker-qual/3.33.0
   url: https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.33.0/checker-qual-3.33.0.pom
   sha1: 6d43e2eacef053cffd73da56734e9a8a138b52be
-- type: file
-  dest: .m2/repository/org/checkerframework/checker-qual/3.37.0
-  url: https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.37.0/checker-qual-3.37.0.pom
-  sha1: 2b5c81b974afb0dad5a99ee7d2540a0bbb0c3555
 - type: file
   dest: .m2/repository/org/checkerframework/checker-qual/3.41.0
   url: https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.41.0/checker-qual-3.41.0.jar
@@ -2363,17 +2279,13 @@
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-xml/3.0.0/plexus-xml-3.0.0.pom
   sha1: f94a34d43206e704670533b74feb981b8de56640
 - type: file
-  dest: .m2/repository/org/cryptomator/cryptofs/2.6.9
-  url: https://repo.maven.apache.org/maven2/org/cryptomator/cryptofs/2.6.9/cryptofs-2.6.9.jar
-  sha1: be39579051dd0ddd23372f070ef32c2c863b3da1
+  dest: .m2/repository/org/cryptomator/cryptofs/2.7.0-beta1
+  url: https://repo.maven.apache.org/maven2/org/cryptomator/cryptofs/2.7.0-beta1/cryptofs-2.7.0-beta1.jar
+  sha1: cf9c741a1370d5f638cd5915d0858b7e393476ef
 - type: file
-  dest: .m2/repository/org/cryptomator/cryptofs/2.6.9
-  url: https://repo.maven.apache.org/maven2/org/cryptomator/cryptofs/2.6.9/cryptofs-2.6.9.pom
-  sha1: b01127f28ae58c6c984990473ced1674aa8b9798
-- type: file
-  dest: .m2/repository/org/cryptomator/cryptolib/2.1.2
-  url: https://repo.maven.apache.org/maven2/org/cryptomator/cryptolib/2.1.2/cryptolib-2.1.2.pom
-  sha1: 91f10561010e71bc945c1047de61d37fb50f34a2
+  dest: .m2/repository/org/cryptomator/cryptofs/2.7.0-beta1
+  url: https://repo.maven.apache.org/maven2/org/cryptomator/cryptofs/2.7.0-beta1/cryptofs-2.7.0-beta1.pom
+  sha1: 2d37e097d0a83140160848dfc47656654e5125b3
 - type: file
   dest: .m2/repository/org/cryptomator/cryptolib/2.2.0
   url: https://repo.maven.apache.org/maven2/org/cryptomator/cryptolib/2.2.0/cryptolib-2.2.0.jar
@@ -2396,20 +2308,24 @@
   sha1: a2977ccfcdfdaa0a364d50ea1d300f888cac4b19
 - type: file
   dest: .m2/repository/org/cryptomator/integrations-api/1.3.1
-  url: https://repo.maven.apache.org/maven2/org/cryptomator/integrations-api/1.3.1/integrations-api-1.3.1.jar
-  sha1: be5cc661b56b3b4352bd57a6c3c8261dfb35b535
-- type: file
-  dest: .m2/repository/org/cryptomator/integrations-api/1.3.1
   url: https://repo.maven.apache.org/maven2/org/cryptomator/integrations-api/1.3.1/integrations-api-1.3.1.pom
   sha1: de2f2d7e97eb62906326d97e03cb28769a1332cc
 - type: file
-  dest: .m2/repository/org/cryptomator/integrations-linux/1.4.5
-  url: https://repo.maven.apache.org/maven2/org/cryptomator/integrations-linux/1.4.5/integrations-linux-1.4.5.jar
-  sha1: 39b0ac05b85a1d323cadfd32c744b386aeb5be14
+  dest: .m2/repository/org/cryptomator/integrations-api/1.4.0-beta2
+  url: https://repo.maven.apache.org/maven2/org/cryptomator/integrations-api/1.4.0-beta2/integrations-api-1.4.0-beta2.jar
+  sha1: 75384c1f2821624a4bb9da99bb40370e37334d5b
 - type: file
-  dest: .m2/repository/org/cryptomator/integrations-linux/1.4.5
-  url: https://repo.maven.apache.org/maven2/org/cryptomator/integrations-linux/1.4.5/integrations-linux-1.4.5.pom
-  sha1: 3fc264f210416187e7b6fe6c1c96c483dacce718
+  dest: .m2/repository/org/cryptomator/integrations-api/1.4.0-beta2
+  url: https://repo.maven.apache.org/maven2/org/cryptomator/integrations-api/1.4.0-beta2/integrations-api-1.4.0-beta2.pom
+  sha1: 0dcae551cbbef14b2fee6766a922fb8bf2e21037
+- type: file
+  dest: .m2/repository/org/cryptomator/integrations-linux/1.5.0-beta4
+  url: https://repo.maven.apache.org/maven2/org/cryptomator/integrations-linux/1.5.0-beta4/integrations-linux-1.5.0-beta4.jar
+  sha1: a6b3ebd7da2905efc86d617de30d56c1a8f893c6
+- type: file
+  dest: .m2/repository/org/cryptomator/integrations-linux/1.5.0-beta4
+  url: https://repo.maven.apache.org/maven2/org/cryptomator/integrations-linux/1.5.0-beta4/integrations-linux-1.5.0-beta4.pom
+  sha1: 581b46268a7bf8a03bc14830d47712d5586fc131
 - type: file
   dest: .m2/repository/org/cryptomator/jfuse/0.7.0
   url: https://repo.maven.apache.org/maven2/org/cryptomator/jfuse/0.7.0/jfuse-0.7.0.jar
@@ -2463,10 +2379,6 @@
   url: https://repo.maven.apache.org/maven2/org/cryptomator/jfuse-win/0.7.0/jfuse-win-0.7.0.pom
   sha1: e7a48e33639c6b537a1f5875a94a58b6679126d5
 - type: file
-  dest: .m2/repository/org/cryptomator/siv-mode/1.4.4
-  url: https://repo.maven.apache.org/maven2/org/cryptomator/siv-mode/1.4.4/siv-mode-1.4.4.pom
-  sha1: 6a2419a0bd616ab06a81c1bfe23c2a051a6fa376
-- type: file
   dest: .m2/repository/org/cryptomator/siv-mode/1.5.2
   url: https://repo.maven.apache.org/maven2/org/cryptomator/siv-mode/1.5.2/siv-mode-1.5.2.jar
   sha1: 98fecde4108ded1b9f2c93cd2290bd334c1b76bf
@@ -2495,10 +2407,6 @@
   url: https://repo.maven.apache.org/maven2/org/eclipse/aether/aether/0.9.0.M2/aether-0.9.0.M2.pom
   sha1: e44bcfab62cbf0ad4f15a47aa9cc48368db2dc6d
 - type: file
-  dest: .m2/repository/org/eclipse/aether/aether/1.0.0.v20140518
-  url: https://repo.maven.apache.org/maven2/org/eclipse/aether/aether/1.0.0.v20140518/aether-1.0.0.v20140518.pom
-  sha1: ea72b6c7e4a69f088a668098249e16ab8810bff3
-- type: file
   dest: .m2/repository/org/eclipse/aether/aether-api/0.9.0.M2
   url: https://repo.maven.apache.org/maven2/org/eclipse/aether/aether-api/0.9.0.M2/aether-api-0.9.0.M2.jar
   sha1: 97662c999c6b2fbf2ee50e814a34639c1c1d22de
@@ -2506,10 +2414,6 @@
   dest: .m2/repository/org/eclipse/aether/aether-api/0.9.0.M2
   url: https://repo.maven.apache.org/maven2/org/eclipse/aether/aether-api/0.9.0.M2/aether-api-0.9.0.M2.pom
   sha1: 3b0bb3ce9bc61aabe2b1a699e2fc92127218f72b
-- type: file
-  dest: .m2/repository/org/eclipse/aether/aether-api/1.0.0.v20140518
-  url: https://repo.maven.apache.org/maven2/org/eclipse/aether/aether-api/1.0.0.v20140518/aether-api-1.0.0.v20140518.pom
-  sha1: b83658f3bcad1dbfaef617a9d0b78f7ba982204b
 - type: file
   dest: .m2/repository/org/eclipse/aether/aether-impl/0.9.0.M2
   url: https://repo.maven.apache.org/maven2/org/eclipse/aether/aether-impl/0.9.0.M2/aether-impl-0.9.0.M2.jar
@@ -2534,10 +2438,6 @@
   dest: .m2/repository/org/eclipse/aether/aether-util/0.9.0.M2
   url: https://repo.maven.apache.org/maven2/org/eclipse/aether/aether-util/0.9.0.M2/aether-util-0.9.0.M2.pom
   sha1: 938d4a7468d46180927cd14ccec6a5accfc428af
-- type: file
-  dest: .m2/repository/org/eclipse/aether/aether-util/1.0.0.v20140518
-  url: https://repo.maven.apache.org/maven2/org/eclipse/aether/aether-util/1.0.0.v20140518/aether-util-1.0.0.v20140518.pom
-  sha1: 183d2dcbfc492540f8a49e0e09f675238257c884
 - type: file
   dest: .m2/repository/org/eclipse/ee4j/project/1.0.7
   url: https://repo.maven.apache.org/maven2/org/eclipse/ee4j/project/1.0.7/project-1.0.7.pom
@@ -2659,13 +2559,13 @@
   url: https://repo.maven.apache.org/maven2/org/freemarker/freemarker/2.3.32/freemarker-2.3.32.pom
   sha1: e4ec1645ca8294f12c0de9f07f9683ebc0d9a36d
 - type: file
-  dest: .m2/repository/org/hamcrest/hamcrest/2.2
-  url: https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest/2.2/hamcrest-2.2.jar
-  sha1: 1820c0968dba3a11a1b30669bb1f01978a91dedc
+  dest: .m2/repository/org/hamcrest/hamcrest/3.0
+  url: https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest/3.0/hamcrest-3.0.jar
+  sha1: 8fd9b78a8e6a6510a078a9e30e9e86a6035cfaf7
 - type: file
-  dest: .m2/repository/org/hamcrest/hamcrest/2.2
-  url: https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest/2.2/hamcrest-2.2.pom
-  sha1: 98624f676c4d263b568816b0af5d4f552a2d0501
+  dest: .m2/repository/org/hamcrest/hamcrest/3.0
+  url: https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest/3.0/hamcrest-3.0.pom
+  sha1: 3c85240a040ddb51dc33d405ef0e075ec68b6796
 - type: file
   dest: .m2/repository/org/infinispan/infinispan-bom/11.0.18.Final
   url: https://repo.maven.apache.org/maven2/org/infinispan/infinispan-bom/11.0.18.Final/infinispan-bom-11.0.18.Final.pom
@@ -2795,53 +2695,61 @@
   url: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.10.2/junit-bom-5.10.2.pom
   sha1: b25ed98a5bd08cdda60e569cf22822a760e76019
 - type: file
-  dest: .m2/repository/org/junit/jupiter/junit-jupiter/5.10.2
-  url: https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter/5.10.2/junit-jupiter-5.10.2.jar
-  sha1: 831c0b86ddc2ce38391c5b81ea662b0cfdc02cce
+  dest: .m2/repository/org/junit/junit-bom/5.11.0
+  url: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.11.0/junit-bom-5.11.0.pom
+  sha1: a4a8a67d5348d748a6345d6f1d08846fb2780ed9
 - type: file
-  dest: .m2/repository/org/junit/jupiter/junit-jupiter/5.10.2
-  url: https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter/5.10.2/junit-jupiter-5.10.2.pom
-  sha1: a36a93123b2617c58d321b1c021df77a1ad4a50c
+  dest: .m2/repository/org/junit/junit-bom/5.11.0-M2
+  url: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.11.0-M2/junit-bom-5.11.0-M2.pom
+  sha1: 6c517cddae7893aba5bf9f051c44860a4fc18211
 - type: file
-  dest: .m2/repository/org/junit/jupiter/junit-jupiter-api/5.10.2
-  url: https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-api/5.10.2/junit-jupiter-api-5.10.2.jar
-  sha1: fb55d6e2bce173f35fd28422e7975539621055ef
+  dest: .m2/repository/org/junit/jupiter/junit-jupiter/5.11.0
+  url: https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter/5.11.0/junit-jupiter-5.11.0.jar
+  sha1: 7ded0835a2522be8e559ac09baff3e9fb2607b27
 - type: file
-  dest: .m2/repository/org/junit/jupiter/junit-jupiter-api/5.10.2
-  url: https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-api/5.10.2/junit-jupiter-api-5.10.2.pom
-  sha1: 93a08d741cad9179423cc229ecbfc016164977d7
+  dest: .m2/repository/org/junit/jupiter/junit-jupiter/5.11.0
+  url: https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter/5.11.0/junit-jupiter-5.11.0.pom
+  sha1: e76f643014a48815a50db5229465a16c9bfb599c
 - type: file
-  dest: .m2/repository/org/junit/jupiter/junit-jupiter-engine/5.10.2
-  url: https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-engine/5.10.2/junit-jupiter-engine-5.10.2.jar
-  sha1: f1f8fe97bd58e85569205f071274d459c2c4f8cd
+  dest: .m2/repository/org/junit/jupiter/junit-jupiter-api/5.11.0
+  url: https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-api/5.11.0/junit-jupiter-api-5.11.0.jar
+  sha1: 02093fd814e940224cfa5a1882d87cc9d81e25c3
 - type: file
-  dest: .m2/repository/org/junit/jupiter/junit-jupiter-engine/5.10.2
-  url: https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-engine/5.10.2/junit-jupiter-engine-5.10.2.pom
-  sha1: 1dfac67b8120dd7ac630a658929fbaf9eb673364
+  dest: .m2/repository/org/junit/jupiter/junit-jupiter-api/5.11.0
+  url: https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-api/5.11.0/junit-jupiter-api-5.11.0.pom
+  sha1: 53931821a6ca5786f5c8bae6839474c82842e736
 - type: file
-  dest: .m2/repository/org/junit/jupiter/junit-jupiter-params/5.10.2
-  url: https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-params/5.10.2/junit-jupiter-params-5.10.2.jar
-  sha1: 359132c82a9d3fa87a325db6edd33b5fdc67a3d8
+  dest: .m2/repository/org/junit/jupiter/junit-jupiter-engine/5.11.0
+  url: https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-engine/5.11.0/junit-jupiter-engine-5.11.0.jar
+  sha1: e0ef3a2222e000e0b5ab76fda0d38d011526f54c
 - type: file
-  dest: .m2/repository/org/junit/jupiter/junit-jupiter-params/5.10.2
-  url: https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-params/5.10.2/junit-jupiter-params-5.10.2.pom
-  sha1: c1a88afb73d74acfc2ba7cbfc578d727e81aea45
+  dest: .m2/repository/org/junit/jupiter/junit-jupiter-engine/5.11.0
+  url: https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-engine/5.11.0/junit-jupiter-engine-5.11.0.pom
+  sha1: 7c950d4fb0e673aaa48cb0e1a713e9480fed8ed4
 - type: file
-  dest: .m2/repository/org/junit/platform/junit-platform-commons/1.10.2
-  url: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/1.10.2/junit-platform-commons-1.10.2.jar
-  sha1: 3197154a1f0c88da46c47a9ca27611ac7ec5d797
+  dest: .m2/repository/org/junit/jupiter/junit-jupiter-params/5.11.0
+  url: https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-params/5.11.0/junit-jupiter-params-5.11.0.jar
+  sha1: 97068da5f462c9a9212516ab58aee632a93c349f
 - type: file
-  dest: .m2/repository/org/junit/platform/junit-platform-commons/1.10.2
-  url: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/1.10.2/junit-platform-commons-1.10.2.pom
-  sha1: 428e90870a1cd83eec09c4d3ae181a71e7e6a467
+  dest: .m2/repository/org/junit/jupiter/junit-jupiter-params/5.11.0
+  url: https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-params/5.11.0/junit-jupiter-params-5.11.0.pom
+  sha1: 37c20f267a2fd39dd2d4a6b27168886c85c1ef5b
 - type: file
-  dest: .m2/repository/org/junit/platform/junit-platform-engine/1.10.2
-  url: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-engine/1.10.2/junit-platform-engine-1.10.2.jar
-  sha1: d53bb4e0ce7f211a498705783440614bfaf0df2e
+  dest: .m2/repository/org/junit/platform/junit-platform-commons/1.11.0
+  url: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/1.11.0/junit-platform-commons-1.11.0.jar
+  sha1: 9bb41eff52781584798c487b68782ae3b4126f14
 - type: file
-  dest: .m2/repository/org/junit/platform/junit-platform-engine/1.10.2
-  url: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-engine/1.10.2/junit-platform-engine-1.10.2.pom
-  sha1: d67d36be92a9dc24fc75cece1a8a9a211ab3641c
+  dest: .m2/repository/org/junit/platform/junit-platform-commons/1.11.0
+  url: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/1.11.0/junit-platform-commons-1.11.0.pom
+  sha1: ee2f489d85590b67e0501d82d2febab764bb782f
+- type: file
+  dest: .m2/repository/org/junit/platform/junit-platform-engine/1.11.0
+  url: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-engine/1.11.0/junit-platform-engine-1.11.0.jar
+  sha1: b981f322be92fe343d4a79f28208bb4475806019
+- type: file
+  dest: .m2/repository/org/junit/platform/junit-platform-engine/1.11.0
+  url: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-engine/1.11.0/junit-platform-engine-1.11.0.pom
+  sha1: 71f7d9e2f117a1583a340065e7e5071ccda33422
 - type: file
   dest: .m2/repository/org/mockito/mockito-bom/4.11.0
   url: https://repo.maven.apache.org/maven2/org/mockito/mockito-bom/4.11.0/mockito-bom-4.11.0.pom
@@ -2907,73 +2815,73 @@
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx/14/javafx-14.pom
   sha1: 731669952fbae02b5b084cdfe38c40d716cd79f7
 - type: file
-  dest: .m2/repository/org/openjfx/javafx/22.0.1
-  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx/22.0.1/javafx-22.0.1.pom
-  sha1: 189ec16e448086384fb53bc0d541b832ae52eab4
+  dest: .m2/repository/org/openjfx/javafx/22.0.2
+  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx/22.0.2/javafx-22.0.2.pom
+  sha1: 4303ce4e88851481c80898960d1ca2be47f3954f
 - type: file
   dest: .m2/repository/org/openjfx/javafx-base/14
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-base/14/javafx-base-14.pom
   sha1: b88958ad83244f1e4af4db7cbc13c5e98b4c473a
 - type: file
-  dest: .m2/repository/org/openjfx/javafx-base/22.0.1
-  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-base/22.0.1/javafx-base-22.0.1.jar
-  sha1: ef7d028cc4b8402f40ce276e60947ef44e4ff805
+  dest: .m2/repository/org/openjfx/javafx-base/22.0.2
+  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-base/22.0.2/javafx-base-22.0.2.jar
+  sha1: 6f3a3d1c3c90fd06de726c31752654a466c0626b
 - type: file
-  dest: .m2/repository/org/openjfx/javafx-base/22.0.1
-  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-base/22.0.1/javafx-base-22.0.1.pom
-  sha1: f795d3c5240c2248b766a3930ec7b754d6cfcfa5
+  dest: .m2/repository/org/openjfx/javafx-base/22.0.2
+  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-base/22.0.2/javafx-base-22.0.2.pom
+  sha1: 6e7c877b54656ff42e2dd9fc6e6c56054291660e
 - type: file
-  dest: .m2/repository/org/openjfx/javafx-base/22.0.1
-  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-base/22.0.1/javafx-base-22.0.1-linux.jar
-  sha1: 8c6b06cb5c235c9c863c2197ca29a3217eb7067d
+  dest: .m2/repository/org/openjfx/javafx-base/22.0.2
+  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-base/22.0.2/javafx-base-22.0.2-linux.jar
+  sha1: 0c831bf8045cac41e9501454e658e61a1bdc1f3e
 - type: file
-  dest: .m2/repository/org/openjfx/javafx-controls/22.0.1
-  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-controls/22.0.1/javafx-controls-22.0.1.jar
-  sha1: e44ea58d6df3e5ecd0b12585ab2f538164156266
+  dest: .m2/repository/org/openjfx/javafx-controls/22.0.2
+  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-controls/22.0.2/javafx-controls-22.0.2.jar
+  sha1: 1e025d0d44355b06f742e71164d0dabe2ebf96d4
 - type: file
-  dest: .m2/repository/org/openjfx/javafx-controls/22.0.1
-  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-controls/22.0.1/javafx-controls-22.0.1.pom
-  sha1: 48205738dc0579d82402a8ff16eea42c1eacd6e8
+  dest: .m2/repository/org/openjfx/javafx-controls/22.0.2
+  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-controls/22.0.2/javafx-controls-22.0.2.pom
+  sha1: e2fe9370950029ce7756a4b1e1548d619ec15be3
 - type: file
-  dest: .m2/repository/org/openjfx/javafx-controls/22.0.1
-  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-controls/22.0.1/javafx-controls-22.0.1-linux.jar
-  sha1: 86075210c7f34de1430eb393b921fd0f5637695a
+  dest: .m2/repository/org/openjfx/javafx-controls/22.0.2
+  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-controls/22.0.2/javafx-controls-22.0.2-linux.jar
+  sha1: 02849d310eaee4c2fb2c4e0078f01be38ed27d96
 - type: file
-  dest: .m2/repository/org/openjfx/javafx-fxml/22.0.1
-  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-fxml/22.0.1/javafx-fxml-22.0.1.jar
-  sha1: 2d89fd02658214fbc1ea661e98104cddb3a13739
+  dest: .m2/repository/org/openjfx/javafx-fxml/22.0.2
+  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-fxml/22.0.2/javafx-fxml-22.0.2.jar
+  sha1: 68a6869a40aca303fad19f7daa3b00d802f409c6
 - type: file
-  dest: .m2/repository/org/openjfx/javafx-fxml/22.0.1
-  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-fxml/22.0.1/javafx-fxml-22.0.1.pom
-  sha1: 815f0e2da889a5d2024347ebb9056ceb1f71819d
+  dest: .m2/repository/org/openjfx/javafx-fxml/22.0.2
+  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-fxml/22.0.2/javafx-fxml-22.0.2.pom
+  sha1: 8aade813538ace12f8ca59c937c402cce592397c
 - type: file
-  dest: .m2/repository/org/openjfx/javafx-fxml/22.0.1
-  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-fxml/22.0.1/javafx-fxml-22.0.1-linux.jar
-  sha1: 1901f3c5b968e32cbf8e256cfe2a599d13062506
+  dest: .m2/repository/org/openjfx/javafx-fxml/22.0.2
+  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-fxml/22.0.2/javafx-fxml-22.0.2-linux.jar
+  sha1: 0afee1498e40790119a6496cb5a09943f64dcde5
 - type: file
-  dest: .m2/repository/org/openjfx/javafx-graphics/22.0.1
-  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-graphics/22.0.1/javafx-graphics-22.0.1.jar
-  sha1: 5e1dad5c22b8708efd8e2c96e2392fe477e3d0be
+  dest: .m2/repository/org/openjfx/javafx-graphics/22.0.2
+  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-graphics/22.0.2/javafx-graphics-22.0.2.jar
+  sha1: a47165f21777e46edf5d8b8c8cc09ef2a9d457c2
 - type: file
-  dest: .m2/repository/org/openjfx/javafx-graphics/22.0.1
-  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-graphics/22.0.1/javafx-graphics-22.0.1.pom
-  sha1: 7a70e0cbeb9ddfa98efe3f101002ece7bbc08971
+  dest: .m2/repository/org/openjfx/javafx-graphics/22.0.2
+  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-graphics/22.0.2/javafx-graphics-22.0.2.pom
+  sha1: 3d6b07f90b47d337f6b1420edd5786c033131911
 - type: file
-  dest: .m2/repository/org/openjfx/javafx-graphics/22.0.1
-  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-graphics/22.0.1/javafx-graphics-22.0.1-linux.jar
-  sha1: c4e6fff7996a4ddd5e1736f4dafca451dbe28b6c
+  dest: .m2/repository/org/openjfx/javafx-graphics/22.0.2
+  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-graphics/22.0.2/javafx-graphics-22.0.2-linux.jar
+  sha1: e2ce99c2c94ed0f8c591a8d6e66bc99c2bfc72be
 - type: file
-  dest: .m2/repository/org/openjfx/javafx-swing/22.0.1
-  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-swing/22.0.1/javafx-swing-22.0.1.jar
-  sha1: a51afb88913ee0f9aa79bb06a8fbe9dc31f004b9
+  dest: .m2/repository/org/openjfx/javafx-swing/22.0.2
+  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-swing/22.0.2/javafx-swing-22.0.2.jar
+  sha1: e9519c7063f3947d6389da041bf4c054225ccead
 - type: file
-  dest: .m2/repository/org/openjfx/javafx-swing/22.0.1
-  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-swing/22.0.1/javafx-swing-22.0.1.pom
-  sha1: 287d2934e245b9d39f9ec6d2caf5abe3f42a8402
+  dest: .m2/repository/org/openjfx/javafx-swing/22.0.2
+  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-swing/22.0.2/javafx-swing-22.0.2.pom
+  sha1: 39a6e79d20e5be8a02ea88479f5d224cb4dd7c85
 - type: file
-  dest: .m2/repository/org/openjfx/javafx-swing/22.0.1
-  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-swing/22.0.1/javafx-swing-22.0.1-linux.jar
-  sha1: 540c35c41f6229f78faa47f80f7d531f68c26b71
+  dest: .m2/repository/org/openjfx/javafx-swing/22.0.2
+  url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-swing/22.0.2/javafx-swing-22.0.2-linux.jar
+  sha1: cf2558647a682d4184cc792807f3c5e1dbb35b50
 - type: file
   dest: .m2/repository/org/opentest4j/opentest4j/1.3.0
   url: https://repo.maven.apache.org/maven2/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar
@@ -3027,21 +2935,17 @@
   url: https://repo.maven.apache.org/maven2/org/purejava/kdewallet/1.4.0/kdewallet-1.4.0.pom
   sha1: 5e1fa1e4037f9982bb1cdbe18afff501a9753a98
 - type: file
-  dest: .m2/repository/org/purejava/libappindicator-gtk3-java-minimal/1.4.0
-  url: https://repo.maven.apache.org/maven2/org/purejava/libappindicator-gtk3-java-minimal/1.4.0/libappindicator-gtk3-java-minimal-1.4.0.jar
-  sha1: 26f3f34243500ffc42c28d35ce6bcd27a129f563
+  dest: .m2/repository/org/purejava/libappindicator-gtk3-java-minimal/1.4.1
+  url: https://repo.maven.apache.org/maven2/org/purejava/libappindicator-gtk3-java-minimal/1.4.1/libappindicator-gtk3-java-minimal-1.4.1.jar
+  sha1: 0cef7db101cee8633a3be0d6c4aab9524746d51c
 - type: file
-  dest: .m2/repository/org/purejava/libappindicator-gtk3-java-minimal/1.4.0
-  url: https://repo.maven.apache.org/maven2/org/purejava/libappindicator-gtk3-java-minimal/1.4.0/libappindicator-gtk3-java-minimal-1.4.0.pom
-  sha1: b10abda0f6b7e15e89ccbd044b4b0d93aa7f19b6
+  dest: .m2/repository/org/purejava/libappindicator-gtk3-java-minimal/1.4.1
+  url: https://repo.maven.apache.org/maven2/org/purejava/libappindicator-gtk3-java-minimal/1.4.1/libappindicator-gtk3-java-minimal-1.4.1.pom
+  sha1: cc4606dc91b9239b9e239295d55e862ea8223eb2
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-api/1.7.5
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.5/slf4j-api-1.7.5.pom
   sha1: 8bef62de94ecb16f574fadc01dcd3127ddb1a4da
-- type: file
-  dest: .m2/repository/org/slf4j/slf4j-api/1.7.35
-  url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.35/slf4j-api-1.7.35.pom
-  sha1: ce822bef88f0d73ca38080326f91186dfe8844c7
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-api/1.7.36
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.jar
@@ -3068,12 +2972,20 @@
   sha1: 783d7a1b137f9a6381a64be951f6690edfedd272
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-api/2.0.13
-  url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/2.0.13/slf4j-api-2.0.13.jar
-  sha1: 80229737f704b121a318bba5d5deacbcf395bc77
-- type: file
-  dest: .m2/repository/org/slf4j/slf4j-api/2.0.13
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/2.0.13/slf4j-api-2.0.13.pom
   sha1: cfe027e08f55e8e5b45f84cbabb4e74e8cd915ec
+- type: file
+  dest: .m2/repository/org/slf4j/slf4j-api/2.0.15
+  url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/2.0.15/slf4j-api-2.0.15.pom
+  sha1: 564a55bf22089d9a7ad2bec7bc2916fa8b6dbfb9
+- type: file
+  dest: .m2/repository/org/slf4j/slf4j-api/2.0.16
+  url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/2.0.16/slf4j-api-2.0.16.jar
+  sha1: 0172931663a09a1fa515567af5fbef00897d3c04
+- type: file
+  dest: .m2/repository/org/slf4j/slf4j-api/2.0.16
+  url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/2.0.16/slf4j-api-2.0.16.pom
+  sha1: 921407ed2b847734f2601db035850cc2473f6453
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-bom/2.0.9
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-bom/2.0.9/slf4j-bom-2.0.9.pom
@@ -3091,6 +3003,14 @@
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-bom/2.0.13/slf4j-bom-2.0.13.pom
   sha1: 7154be9a411f51d833e40a654ec8bf738aaa394a
 - type: file
+  dest: .m2/repository/org/slf4j/slf4j-bom/2.0.15
+  url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-bom/2.0.15/slf4j-bom-2.0.15.pom
+  sha1: ad35b9a1a57baa1559fc4b03f520854818249773
+- type: file
+  dest: .m2/repository/org/slf4j/slf4j-bom/2.0.16
+  url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-bom/2.0.16/slf4j-bom-2.0.16.pom
+  sha1: 4e5740a21ebbd1ef8187340d92ac1f6e2c654b62
+- type: file
   dest: .m2/repository/org/slf4j/slf4j-log4j12/1.6.4
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-log4j12/1.6.4/slf4j-log4j12-1.6.4.pom
   sha1: ab93dfaa2fb9619d91fb31a64bb65802b56ed0fb
@@ -3102,10 +3022,6 @@
   dest: .m2/repository/org/slf4j/slf4j-parent/1.7.5
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/1.7.5/slf4j-parent-1.7.5.pom
   sha1: 2955681f952b108824dfb16ca366f36f3cef7861
-- type: file
-  dest: .m2/repository/org/slf4j/slf4j-parent/1.7.35
-  url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/1.7.35/slf4j-parent-1.7.35.pom
-  sha1: 71102714016472f7af795b5de20bc752df640263
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-parent/1.7.36
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/1.7.36/slf4j-parent-1.7.36.pom
@@ -3130,6 +3046,14 @@
   dest: .m2/repository/org/slf4j/slf4j-parent/2.0.13
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/2.0.13/slf4j-parent-2.0.13.pom
   sha1: 47cc245b4e806907ef2612563e4c124c15f99a44
+- type: file
+  dest: .m2/repository/org/slf4j/slf4j-parent/2.0.15
+  url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/2.0.15/slf4j-parent-2.0.15.pom
+  sha1: 55f13bc1b4d0cbd8ec72c932a1d9d51c9712d0d4
+- type: file
+  dest: .m2/repository/org/slf4j/slf4j-parent/2.0.16
+  url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/2.0.16/slf4j-parent-2.0.16.pom
+  sha1: dcfa3309fdfcea2baf81d70a1d47172baf24a334
 - type: file
   dest: .m2/repository/org/sonatype/forge/forge-parent/4
   url: https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/4/forge-parent-4.pom

--- a/org.cryptomator.Cryptomator.yaml
+++ b/org.cryptomator.Cryptomator.yaml
@@ -141,6 +141,7 @@ modules:
       - maven-dependencies.yaml
       - maven-dependencies-x86_64.yaml
       - maven-dependencies-aarch64.yaml
+      ##TODO: use stable version
       - type: archive
         sha512: ff4d5d23d7fea3d9ad0b1b26db3a985b59dcc9af66b8cb3a614cedd2a657218b600c9573c88e60b43f9c4770ec75826e30bab95840f19384e4dacb2e08080ce9 #CRYPTOMATOR - COMMENT REQUIRED FOR AUTOMATION
         url: https://github.com/cryptomator/cryptomator/archive/refs/tags/1.14.0-beta2.tar.gz

--- a/org.cryptomator.Cryptomator.yaml
+++ b/org.cryptomator.Cryptomator.yaml
@@ -125,8 +125,6 @@ modules:
         --java-options '-Dcryptomator.settingsPath='@{userhome}/.config/Cryptomator/settings.json:~/.Cryptomator/settings.json''
         --java-options '-Dcryptomator.showTrayIcon=true'
         --java-options '-Dcryptomator.disableUpdateCheck=true'
-        --java-options "-Dcryptomator.integrationsLinux.autoStartCmd='flatpak run org.cryptomator.Cryptomator'" #TODO: test
-
         --app-version "${VERSION}.${REVISION_NO}"
         --verbose
       - cp -R Cryptomator /app/

--- a/org.cryptomator.Cryptomator.yaml
+++ b/org.cryptomator.Cryptomator.yaml
@@ -139,10 +139,9 @@ modules:
       - maven-dependencies.yaml
       - maven-dependencies-x86_64.yaml
       - maven-dependencies-aarch64.yaml
-      ##TODO: use stable version
       - type: archive
-        sha512: ff4d5d23d7fea3d9ad0b1b26db3a985b59dcc9af66b8cb3a614cedd2a657218b600c9573c88e60b43f9c4770ec75826e30bab95840f19384e4dacb2e08080ce9 #CRYPTOMATOR - COMMENT REQUIRED FOR AUTOMATION
-        url: https://github.com/cryptomator/cryptomator/archive/refs/tags/1.14.0-beta2.tar.gz
+        sha512: 168d875f3ff3e258469fffc9f5be228120f8c0e93f823b299142c72853d378143f254051695c7ac2790c48adab512aef5e81667c189d898b1daff6ff34567498 #CRYPTOMATOR - COMMENT REQUIRED FOR AUTOMATION
+        url: https://github.com/cryptomator/cryptomator/archive/refs/tags/1.14.0.tar.gz
       - type: file
         dest-filename: jdk.tar.gz
         only-arches:

--- a/org.cryptomator.Cryptomator.yaml
+++ b/org.cryptomator.Cryptomator.yaml
@@ -78,8 +78,8 @@ modules:
         MAVEN_OPTS: -Dmaven.repo.local=.m2/repository
         JAVA_HOME: jdk
         JMODS_PATH: jmods:${JAVA_HOME}/jmods
-        VERSION: 1.13.0
-        REVISION_NO: '2'
+        VERSION: 1.14.0
+        REVISION_NO: '1'
     build-commands:
       # Setup Java
       - tar xvfz jdk.tar.gz --transform 's!^[^/]*!jdk!'
@@ -89,13 +89,13 @@ modules:
       - mkdir maven
       - tar xf maven.tar.gz --strip-components=1 --exclude=jansi-native --directory=maven
       # Build project
-      - maven/bin/mvn clean package -DskipTests -Plinux
+      - maven/bin/mvn clean package -DskipTests -Plinux -Djavafx.platform=linux
       - cp target/cryptomator-*.jar target/mods
       - cd target
       - $JAVA_HOME/bin/jlink
         --output runtime
         --module-path $JMODS_PATH
-        --add-modules java.base,java.desktop,java.instrument,java.logging,java.naming,java.net.http,java.scripting,java.sql,java.xml,javafx.base,javafx.graphics,javafx.controls,javafx.fxml,jdk.unsupported,jdk.security.auth,jdk.accessibility,jdk.management.jfr,jdk.net
+        --add-modules java.base,java.desktop,java.instrument,java.logging,java.naming,java.net.http,java.scripting,java.sql,java.xml,javafx.base,javafx.graphics,javafx.controls,javafx.fxml,jdk.unsupported,jdk.security.auth,jdk.accessibility,jdk.management.jfr,jdk.net,java.compiler
         --no-header-files
         --no-man-pages
         --strip-debug
@@ -125,6 +125,8 @@ modules:
         --java-options '-Dcryptomator.settingsPath='@{userhome}/.config/Cryptomator/settings.json:~/.Cryptomator/settings.json''
         --java-options '-Dcryptomator.showTrayIcon=true'
         --java-options '-Dcryptomator.disableUpdateCheck=true'
+        --java-options "-Dcryptomator.integrationsLinux.autoStartCmd='flatpak run org.cryptomator.Cryptomator'" #TODO: test
+
         --app-version "${VERSION}.${REVISION_NO}"
         --verbose
       - cp -R Cryptomator /app/
@@ -140,33 +142,33 @@ modules:
       - maven-dependencies-x86_64.yaml
       - maven-dependencies-aarch64.yaml
       - type: archive
-        sha512: 026bdce7cbb206ba1f2751dbec30e0d07bb1926e3603a877eae69071e4db911e2179e64a8c35169ff47b0bf94161a4acf10bff9d660e4f56663ebb8c0d91b437 #CRYPTOMATOR - COMMENT REQUIRED FOR AUTOMATION
-        url: https://github.com/cryptomator/cryptomator/archive/refs/tags/1.13.0.tar.gz
+        sha512: ff4d5d23d7fea3d9ad0b1b26db3a985b59dcc9af66b8cb3a614cedd2a657218b600c9573c88e60b43f9c4770ec75826e30bab95840f19384e4dacb2e08080ce9 #CRYPTOMATOR - COMMENT REQUIRED FOR AUTOMATION
+        url: https://github.com/cryptomator/cryptomator/archive/refs/tags/1.14.0-beta2.tar.gz
       - type: file
+        dest-filename: jdk.tar.gz
         only-arches:
           - x86_64
-        url: https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jdk_x64_linux_hotspot_22.0.1_8.tar.gz
-        sha512: 2f9cb8e6ab5c9097ad0d9dc482d913aa3de5d4b9f0868bfc909b3e799a4b4d07b045fb46cd94067ed608a0a925edb30e5d81a9cf2bf9cad6a6bb1564c4ee9c11
-        dest-filename: jdk.tar.gz
+        url: https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.2%2B9/OpenJDK22U-jdk_x64_linux_hotspot_22.0.2_9.tar.gz
+        sha512: 63279c060903dfdc548b4e8c13822f39bf1fe1951f26f9345e8501eda9a992f9120706a09dc02a8ce48640c118239b8d0aa577a166d5a1422a8e1e6f14f32d74
       - type: file
+        dest-filename: jdk.tar.gz
         only-arches:
           - aarch64
-        url: https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jdk_aarch64_linux_hotspot_22.0.1_8.tar.gz
-        sha512: efbeb6dedcd13450c31ee0899cc8e6a9ece372b3bb781442129595cf5d8353816287f8712b84f5294aaf0bef2fc0453568ed2953c739e4e50b7a4460aa3cf33f
-        dest-filename: jdk.tar.gz
+        url: https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.2%2B9/OpenJDK22U-jdk_aarch64_linux_hotspot_22.0.2_9.tar.gz
+        sha512: f6db50f3ba1e6a9515685f4cce5221a999ed6b079541824b0ee62d7cc3fec92c8abd3da8f12302fd60975adaced2035d1eb697dcd4830c75d9e722815bf5bbcb
       - type: file
+        dest-filename: openjfx.zip
         only-arches:
           - x86_64
-        url: https://download2.gluonhq.com/openjfx/22.0.1/openjfx-22.0.1_linux-x64_bin-jmods.zip
-        sha512: 13d5f46689180496484660274b1bf6e7d13dc64986be72d300f757bc46b730c2800f2c85dc688e74f0a39d83e1140ab10d2bb1297459228073e9701b72aea385
-        dest-filename: openjfx.zip
+        url: https://download2.gluonhq.com/openjfx/22.0.2/openjfx-22.0.2_linux-x64_bin-jmods.zip
+        sha512: 218e6808b7728c291c5e7316906f7f754da1aba157d4e6c87f6e6579d5b5459da757ed14757e6fa5c316e030020c3de53814ab99648ae78cb19eb4b8d2bb88ac
       - type: file
+        dest-filename: openjfx.zip
         only-arches:
           - aarch64
-        url: https://download2.gluonhq.com/openjfx/22.0.1/openjfx-22.0.1_linux-aarch64_bin-jmods.zip
-        sha512: 82aaeaaa421e0529979908a321cd3c9ab8412247b2f493f1e09063a978848ad104331cb8213f3e1d440eacb01154088caabcdea5a32e4952c83edc6da4cbbedb
-        dest-filename: openjfx.zip
+        url: https://download2.gluonhq.com/openjfx/22.0.2/openjfx-22.0.2_linux-aarch64_bin-jmods.zip
+        sha512: 799180c0944d3287ab20b3148ec537d0de7162d162d7ac75a1d016e018b6fb482bb914e35b687145c7bb9d5c9afbae1bd165492179ff0ee6528340a4feb4c3c6
       - type: file
-        url: https://dlcdn.apache.org/maven/maven-3/3.9.5/binaries/apache-maven-3.9.5-bin.tar.gz
-        sha512: 4810523ba025104106567d8a15a8aa19db35068c8c8be19e30b219a1d7e83bcab96124bf86dc424b1cd3c5edba25d69ec0b31751c136f88975d15406cab3842b
         dest-filename: maven.tar.gz
+        url: https://dlcdn.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz
+        sha512: a555254d6b53d267965a3404ecb14e53c3827c09c3b94b5678835887ab404556bfaf78dcfe03ba76fa2508649dca8531c74bca4d5846513522404d48e8c4ac8b


### PR DESCRIPTION
This PR updates the Cryptomator flatpak to version 1.14.0

Changes:
* add java.compiler module to runtime
* update maven to 3.9.9 and add `-Djavafx.platform=linux` property
* update JDK to 22.0.2+9
* update JFX to 22.0.2