### PR TITLE
fix: allow access to external drive mountpoint by default

### DIFF
--- a/org.cryptomator.Cryptomator.yaml
+++ b/org.cryptomator.Cryptomator.yaml
@@ -16,6 +16,9 @@ finish-args:
   # Needed to connect to KeePassXC's UNIX domain socket
   - --filesystem=xdg-run/org.keepassxc.KeePassXC.BrowserServer
   - --filesystem=xdg-run/app/org.keepassxc.KeePassXC/
+  # Allow filesystem access to standard mountpoint /run/media
+  # Needed to manage vaults on external drives
+  - --filesystem=/run/media
   # Share IPC namespace with the host, without it the X11 shared memory extension will not work
   - --share=ipc
   # Allow access to the network


### PR DESCRIPTION
### Description
Response to [#3608](https://github.com/cryptomator/cryptomator/issues/3608) in source repo. This change allows the sandboxed application access to the default mountpoint for external drives, supporting a workflow where a vault may be located on such a drive out of box.
### Issues
On systems where the default mountpoint is not /run/media and is not symlinked there, manual configuration will still be required. This mimics behavior prior to PR.


Thank you for maintaining this project. If you have any further questions, please reach out via PR comments.