### PR TITLE
Trigger new build

### DIFF
--- a/org.cryptomator.Cryptomator.yaml
+++ b/org.cryptomator.Cryptomator.yaml
@@ -136,6 +136,7 @@ modules:
       - install -D -m0644 -t /app/share/icons/hicolor/scalable/apps/ dist/linux/common/org.cryptomator.Cryptomator.svg
       - install -D -m0644 -T dist/linux/common/org.cryptomator.Cryptomator.tray.svg /app/share/icons/hicolor/symbolic/apps/org.cryptomator.Cryptomator.tray-symbolic.svg
       - install -D -m0644 -T dist/linux/common/org.cryptomator.Cryptomator.tray-unlocked.svg /app/share/icons/hicolor/symbolic/apps/org.cryptomator.Cryptomator.tray-unlocked-symbolic.svg
+      - sed -i 's/MainWindowUnlock_dark.png/MainWindowUnlocked_dark.png/g' dist/linux/common/org.cryptomator.Cryptomator.metainfo.xml #patch metainfo file with correct screenshot
       - install -D -m0644 -t /app/share/metainfo/ dist/linux/common/org.cryptomator.Cryptomator.metainfo.xml
     sources:
       - maven-dependencies.yaml


### PR DESCRIPTION
For an explanation see https://discourse.flathub.org/t/flathub-page-is-not-updated/8856/4 

I added a patch for a badly named file and adjusted also the statit url on the server. The new screenshot file can be found in https://static.cryptomator.org/desktop/flathubScreenshots/MainWindowUnlocked_dark.png