### PR TITLE
Feature: Update maven stuff

### DIFF
--- a/maven-dependencies-aarch64.yaml
+++ b/maven-dependencies-aarch64.yaml
@@ -1,30 +1,25 @@
 - type: file
   dest: .m2/repository/org/openjfx/javafx-base/24.0.1
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-base/24.0.1/javafx-base-24.0.1-linux-aarch64.jar
-  sha1: 83340233e069b98a9fcf5b8196145a5eb8a3d870
-  only-arches:
-    - aarch64
+  sha256: 816c2f2ebe1c4661eb4253e4d8077552d7becc7423ba92dfb846b7a1ac4849ae
+  only-arches: [aarch64]
 - type: file
   dest: .m2/repository/org/openjfx/javafx-controls/24.0.1
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-controls/24.0.1/javafx-controls-24.0.1-linux-aarch64.jar
-  sha1: 02b8715e07579c3de1bd50fe51209666bba52d48
-  only-arches:
-    - aarch64
+  sha256: 38c8376c062fd61f474b1782323a1d0ae0d4c977468b485f7a490cc49497db9d
+  only-arches: [aarch64]
 - type: file
   dest: .m2/repository/org/openjfx/javafx-fxml/24.0.1
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-fxml/24.0.1/javafx-fxml-24.0.1-linux-aarch64.jar
-  sha1: 860f1572838e5432b0a73b0b703928d424c6e2f0
-  only-arches:
-    - aarch64
+  sha256: 1fd927ca39b76e97f60a9639e8c278556209b4e399bff85b8e75c2d4b827d2a8
+  only-arches: [aarch64]
 - type: file
   dest: .m2/repository/org/openjfx/javafx-graphics/24.0.1
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-graphics/24.0.1/javafx-graphics-24.0.1-linux-aarch64.jar
-  sha1: cd153842a963efe000f038561a03b45bc8ce3307
-  only-arches:
-    - aarch64
+  sha256: a4340208158181c9ac8138b2fbd1703b49170c38010dab4a9e67bdcc6e56cba9
+  only-arches: [aarch64]
 - type: file
   dest: .m2/repository/org/openjfx/javafx-swing/24.0.1
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-swing/24.0.1/javafx-swing-24.0.1-linux-aarch64.jar
-  sha1: b7aa5250db1e86c9decbe0c99e354dd9e57f0d5b
-  only-arches:
-    - aarch64
+  sha256: d1083583ecaa2764747af8bdfaea09893008f103b3c94c9acac5ac5ff7b61d69
+  only-arches: [aarch64]

--- a/maven-dependencies-x86_64.yaml
+++ b/maven-dependencies-x86_64.yaml
@@ -1,30 +1,25 @@
 - type: file
   dest: .m2/repository/org/openjfx/javafx-base/24.0.1
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-base/24.0.1/javafx-base-24.0.1-linux.jar
-  sha1: 1eb0dd4c9b54075b121b2246c41e2ff767b81768
-  only-arches:
-  - x86_64
+  sha256: 3b0e669058796a496757bb17d14e5d97a1b412ca5c1b3f1e0159f6e5d8ee23db
+  only-arches: [x86_64]
 - type: file
   dest: .m2/repository/org/openjfx/javafx-controls/24.0.1
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-controls/24.0.1/javafx-controls-24.0.1-linux.jar
-  sha1: 8946a980ee0077bd28752db645155fb292931d6e
-  only-arches:
-  - x86_64
+  sha256: 699bce2d936091ed00f17b7fb4f28c4f09a4eb5d38005d1a64dd3105d8d72d37
+  only-arches: [x86_64]
 - type: file
   dest: .m2/repository/org/openjfx/javafx-fxml/24.0.1
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-fxml/24.0.1/javafx-fxml-24.0.1-linux.jar
-  sha1: f9eb3b46f2d361a9f8bb24c0db4c56e0ca7d1c20
-  only-arches:
-  - x86_64
+  sha256: a88c7b44e524b3cfa5a921f787a3abb89c82761226dc2f2743e5e79718b2fa13
+  only-arches: [x86_64]
 - type: file
   dest: .m2/repository/org/openjfx/javafx-graphics/24.0.1
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-graphics/24.0.1/javafx-graphics-24.0.1-linux.jar
-  sha1: c0b9013d797e001b364baaa14cbe988b2dea28bf
-  only-arches:
-  - x86_64
+  sha256: e6f489b9eb0be06d06b307df61fdf0bd4d9e4a66b18c9d1c53ce600e00cc66eb
+  only-arches: [x86_64]
 - type: file
   dest: .m2/repository/org/openjfx/javafx-swing/24.0.1
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-swing/24.0.1/javafx-swing-24.0.1-linux.jar
-  sha1: 568a7d38db8833884a96ccec96b90e1836090707
-  only-arches:
-  - x86_64
+  sha256: 0c9c304250b72414653bcbda145225342351e9183046fcdbc139893ba9635edd
+  only-arches: [x86_64]

--- a/maven-dependencies.yaml
+++ b/maven-dependencies.yaml
@@ -1,2820 +1,2820 @@
 - type: file
   dest: .m2/repository/at/favre/lib/common-parent/18
   url: https://repo.maven.apache.org/maven2/at/favre/lib/common-parent/18/common-parent-18.pom
-  sha1: 7567d1d8c4e4c069d96e35457bd67ad9d3895124
+  sha256: 4cc5ce3b39a14271b865147ea2bba54f93ebea459d7a010e698f0e190c1fee8e
 - type: file
   dest: .m2/repository/at/favre/lib/hkdf/2.0.0
   url: https://repo.maven.apache.org/maven2/at/favre/lib/hkdf/2.0.0/hkdf-2.0.0.jar
-  sha1: 26394a6d64d6bfaf88954cf695e699ed9c66bfb9
+  sha256: 65aa13f71a1a8b9cac439504af213d761fef9b002b6d06f06c16e50f86ec422b
 - type: file
   dest: .m2/repository/at/favre/lib/hkdf/2.0.0
   url: https://repo.maven.apache.org/maven2/at/favre/lib/hkdf/2.0.0/hkdf-2.0.0.pom
-  sha1: b1ef02cb697350294b9ce393d9cf775f45f8b183
+  sha256: 5676992b0366ec923e3d01744c79dff54f3d111027b15b7a5feaed90b6f9946d
 - type: file
   dest: .m2/repository/ch/qos/logback/logback-classic/1.5.18
   url: https://repo.maven.apache.org/maven2/ch/qos/logback/logback-classic/1.5.18/logback-classic-1.5.18.jar
-  sha1: fc371f3fc97a639de2d67947cffb7518ec5e3d40
+  sha256: 3e1533d0321f8815eef46750aee0111b41554f9a4644c3c4d2d404744b09f60f
 - type: file
   dest: .m2/repository/ch/qos/logback/logback-classic/1.5.18
   url: https://repo.maven.apache.org/maven2/ch/qos/logback/logback-classic/1.5.18/logback-classic-1.5.18.pom
-  sha1: 19f6cb01d310be728155db4abf63d8395a6a0b45
+  sha256: d557cd2ab23de4a47ece870642162a9f94739fcd0b1c313e27832514ee203833
 - type: file
   dest: .m2/repository/ch/qos/logback/logback-core/1.5.18
   url: https://repo.maven.apache.org/maven2/ch/qos/logback/logback-core/1.5.18/logback-core-1.5.18.jar
-  sha1: 6c0375624f6f36b4e089e2488ba21334a11ef13f
+  sha256: 85139e7b57b464f8e5e36326dd81317648bed199ccc4f98cd42585f8d7571027
 - type: file
   dest: .m2/repository/ch/qos/logback/logback-core/1.5.18
   url: https://repo.maven.apache.org/maven2/ch/qos/logback/logback-core/1.5.18/logback-core-1.5.18.pom
-  sha1: b08ee05116e297660d31f7303dca7a34f80dc78b
+  sha256: c77247297d5d9bb9e04e92d4c82e75c6e8eabe245436892f9114335b8b790c83
 - type: file
   dest: .m2/repository/ch/qos/logback/logback-parent/1.5.18
   url: https://repo.maven.apache.org/maven2/ch/qos/logback/logback-parent/1.5.18/logback-parent-1.5.18.pom
-  sha1: 1e510753b365bdd014c4c95fda03ecb432c10210
+  sha256: 53c3e21b123bbd38a301b40d0d814094ead47a1023d21d613cc748d70e7b9c69
 - type: file
   dest: .m2/repository/com/auth0/java-jwt/4.5.0
   url: https://repo.maven.apache.org/maven2/com/auth0/java-jwt/4.5.0/java-jwt-4.5.0.jar
-  sha1: d7004155fe57a107cc40fb6be0132d8ad2530613
+  sha256: defc50d5066630d46737ba3077e1e13df7201baf5817394c9a4d3d23e2ad3019
 - type: file
   dest: .m2/repository/com/auth0/java-jwt/4.5.0
   url: https://repo.maven.apache.org/maven2/com/auth0/java-jwt/4.5.0/java-jwt-4.5.0.pom
-  sha1: 19f9cc615e21f7e6a360701db3dfe4ae688554a9
+  sha256: a7235c7679e25daeba5b8d45ac0f2d4f681b16e38ec41859ed3d77a0c6182c48
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.15.4
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.15.4/jackson-annotations-2.15.4.pom
-  sha1: 657793cf31fc48360c540b3152e2cc2b63bba8ac
+  sha256: 7d5d5bacf8526e4bff2ed5fecc193e4a03da29a29b5b1b2c7ea6220dda0067f5
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.19.1
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.19.1/jackson-annotations-2.19.1.jar
-  sha1: 37e4f0c5dba684e00137defdb04ad9df95920c44
+  sha256: 5a3cd7211ab26b36213f43a2a94bc052a3385af780c5c135329741b2d79a9730
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.19.1
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.19.1/jackson-annotations-2.19.1.pom
-  sha1: 00793ec52fb40c0f338bb7f00d5b8f11923090b6
+  sha256: d7da4c683e3c792735a6f4b6c71c041745e2b1d703590350ab9acf4ae7f3cb2d
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/core/jackson-core/2.15.4
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.15.4/jackson-core-2.15.4.pom
-  sha1: 88cfb3d9dc12de7c26caccc26bcec9d7495d1779
+  sha256: 73e2105b84d751aeb20d1f39f92b5a53b336211ec9abe82345255355f0575a12
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/core/jackson-core/2.19.1
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.19.1/jackson-core-2.19.1.jar
-  sha1: 6e5a8cb8a6cada322497cefb7726657d98aaee15
+  sha256: c46369e1a21810100adbc92503b62f15a9ef1640427932f4fe1588ef7ce7e480
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/core/jackson-core/2.19.1
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.19.1/jackson-core-2.19.1.pom
-  sha1: e5a7d2b1178608a1b8dce857c167b3af713fa700
+  sha256: 0a26a2cdb77e1f81bd926d23b8d586c395cf3d8891932ad70370fd461b487d1a
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/core/jackson-databind/2.15.4
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.15.4/jackson-databind-2.15.4.pom
-  sha1: fd9ae9b5ab8f9fb0d3655cbe1714305d0e7d4b51
+  sha256: 0ce8d18b90acc0fcffddda30ca5da93ea4450b276d066d9e3029c03b092705a4
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/core/jackson-databind/2.19.1
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.19.1/jackson-databind-2.19.1.jar
-  sha1: e8cb8e76faea3e0791165f5d3614fc45933b2ee0
+  sha256: 0bc539401d52c6b14e668947c851dcc49f78a4ada3d1fc8e8f71440613fc26ce
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/core/jackson-databind/2.19.1
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.19.1/jackson-databind-2.19.1.pom
-  sha1: df62196a8877cedde4f6a889b120a16d5b0e9dc8
+  sha256: d0581490b3a55b4a620f90f1f3cad2856e6f2d810e4e7b4caef080358539a8c0
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.19.1
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.19.1/jackson-datatype-jsr310-2.19.1.jar
-  sha1: e9df57105f3b0730040ad7f3a1b603684a3329f4
+  sha256: 366eb89065d568a7c0ede73c26a343f293f076d2f8efd0dc69cbe574ca01220e
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.19.1
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.19.1/jackson-datatype-jsr310-2.19.1.pom
-  sha1: 13f117ebd00d4cf98442dd57bdf370456dbf14e6
+  sha256: 05be7a7a90fa67495f61aa3c4fbde9b66fea97d223ac569fa1d38387532cd4a7
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/jackson-base/2.15.4
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-base/2.15.4/jackson-base-2.15.4.pom
-  sha1: 5d17a21a197dd7b2271db88f9094fb49f8550eab
+  sha256: 74e3ad3c08aa3710299f3582538e07ed8c5026c3c128b66a6189763d74e58c88
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/jackson-base/2.19.1
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-base/2.19.1/jackson-base-2.19.1.pom
-  sha1: d559d5dd385493b5f7257645886c1bbd36acf215
+  sha256: b73170086622718aa7d6c1ac0a949b6550f9bd14a44672c1a3f2b8e7b7682e14
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/jackson-bom/2.15.4
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-bom/2.15.4/jackson-bom-2.15.4.pom
-  sha1: 2ed3947aac4ec7d5a3b8c1c89821056a7203b09b
+  sha256: 6cc2d925fcadf5cd225254cbf4e4a78bb9af9194d018717733d598461e35fd98
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/jackson-bom/2.16.1
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-bom/2.16.1/jackson-bom-2.16.1.pom
-  sha1: 0e56871cbeb604dfdce9ffac8ce705d049f478cf
+  sha256: 69d8bf9b2a7d42c9cf1d70ad82be42f6ac6fd788918a6e1d75792ecdcc117a0b
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/jackson-bom/2.17.2
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-bom/2.17.2/jackson-bom-2.17.2.pom
-  sha1: e772457e00739867a8f382ef0a8c4dcb03558772
+  sha256: 1f472b0bc2004d5cf421ac48871417f84189e78f35c049718387fd8b44fb9f32
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/jackson-bom/2.18.1
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-bom/2.18.1/jackson-bom-2.18.1.pom
-  sha1: 6c3f94967a4d65b989e2cb2f9abb79a7557728cf
+  sha256: f384abccaf0c6fbd76183762f7256fd679012ed81db7f2a26687e8b965a014a7
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/jackson-bom/2.19.1
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-bom/2.19.1/jackson-bom-2.19.1.pom
-  sha1: 849979babb3cff0dc2a47cf13d43e379d17b4839
+  sha256: ba6d68eeab3a1cc13a77a8ade2197ff9a32aa1cffeac72847d49badd82e1b9ce
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/jackson-parent/2.15
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-parent/2.15/jackson-parent-2.15.pom
-  sha1: caffbeb9be9350780ad5407789f43664906042ec
+  sha256: 6cdf97bc66f389f63e36850d2f552d1216688f8e5a58727d3f6a98edf8675cde
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/jackson-parent/2.16
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-parent/2.16/jackson-parent-2.16.pom
-  sha1: 712d723d9a99b84ce364361e155857377c16de96
+  sha256: 8bf6142812148a2abf6850b272f0af4c3d8ff1121ed604c402f3f38c9e6546ab
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/jackson-parent/2.17
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-parent/2.17/jackson-parent-2.17.pom
-  sha1: df97fedb1aae67d608a69fa9262410247f3d31af
+  sha256: aee6de4a97283b040e43f4dad575e7b74796cd984d89276f7ec7567380c8a29d
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/jackson-parent/2.18.1
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-parent/2.18.1/jackson-parent-2.18.1.pom
-  sha1: fcd5c9c72aeebb63d13eb4330842fdb8ae4f9a1c
+  sha256: d0822fac1a0226844b8ad445c920c49a4f619169d09b1010a7dfeed19910998c
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/jackson-parent/2.19.2
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-parent/2.19.2/jackson-parent-2.19.2.pom
-  sha1: c3dda446ba6d44f47123d670847d8b005857bd45
+  sha256: 639a2b63dd05da4e381081303985caadfbb7ad9f85b1d2320638f6b11f208365
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/module/jackson-modules-java8/2.19.1
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/module/jackson-modules-java8/2.19.1/jackson-modules-java8-2.19.1.pom
-  sha1: 4ef9df171f7bf40aaa122f2d83d6c586504bb81c
+  sha256: 7fc679f1a7b746f905bf6a0c5c7d3cddaca236715a756a8cc01e8b8a50f1954e
 - type: file
   dest: .m2/repository/com/fasterxml/oss-parent/50
   url: https://repo.maven.apache.org/maven2/com/fasterxml/oss-parent/50/oss-parent-50.pom
-  sha1: 2e5ec5928fa4a136254d3dfeb8c56f47b049d8ed
+  sha256: f5da55dd7b88fb170c46801d17774a652fb2f4581fb5b1d0a5fc86aa182b8577
 - type: file
   dest: .m2/repository/com/fasterxml/oss-parent/56
   url: https://repo.maven.apache.org/maven2/com/fasterxml/oss-parent/56/oss-parent-56.pom
-  sha1: 355a98a7c92b8dd838bf0b32b04fd991bec14570
+  sha256: fd491f78857424106d2e3d605bcd799b53d31a565cdc868463ca7e875db45a50
 - type: file
   dest: .m2/repository/com/fasterxml/oss-parent/58
   url: https://repo.maven.apache.org/maven2/com/fasterxml/oss-parent/58/oss-parent-58.pom
-  sha1: 0ed9e5d9e7cad24fce51b18455e0cf5ccd2c94b6
+  sha256: 5670e6ac1c4ddcc9d413cf87997a5da2efaa4d2abe439363af9ef102a0a09e40
 - type: file
   dest: .m2/repository/com/fasterxml/oss-parent/61
   url: https://repo.maven.apache.org/maven2/com/fasterxml/oss-parent/61/oss-parent-61.pom
-  sha1: 8a4169cc2907589f72b053e7b9b02cb741bf1e46
+  sha256: 3649513cf597e9186da0855986a8c543e12bdbd805edeef9c124db56dd036544
 - type: file
   dest: .m2/repository/com/fasterxml/oss-parent/68
   url: https://repo.maven.apache.org/maven2/com/fasterxml/oss-parent/68/oss-parent-68.pom
-  sha1: f19ecade22562dcd5a3520a35d60225008c16a29
+  sha256: 25eafd96dae242b6b5a7108f55b2c14015b828daa5abe234289fd6e774a1ce57
 - type: file
   dest: .m2/repository/com/github/andrewoma/dexx/collection/0.7
   url: https://repo.maven.apache.org/maven2/com/github/andrewoma/dexx/collection/0.7/collection-0.7.jar
-  sha1: 264efc08bdcd22126bd429aaea9efaf5158b2b90
+  sha256: e50cbc8379325ee17e8127eed7eb88fb70b94ba16e5e3d97e12401a1fc248fb8
 - type: file
   dest: .m2/repository/com/github/andrewoma/dexx/collection/0.7
   url: https://repo.maven.apache.org/maven2/com/github/andrewoma/dexx/collection/0.7/collection-0.7.pom
-  sha1: 889fb838b05fc2181662450f06740569c2e1ec23
+  sha256: 404c5aaea44cfb9fcab91f5c657280b8dfb1757f2fa991848cc4e5ec4a837a5a
 - type: file
   dest: .m2/repository/com/github/ben-manes/caffeine/caffeine/3.2.0
   url: https://repo.maven.apache.org/maven2/com/github/ben-manes/caffeine/caffeine/3.2.0/caffeine-3.2.0.pom
-  sha1: a0337955d691c153f1ee0bc27f6b5bc3dbe2ca9f
+  sha256: bf418ab677a31782502229a8fb35bf573f88a36678ec076d6e9337d383e5eae6
 - type: file
   dest: .m2/repository/com/github/ben-manes/caffeine/caffeine/3.2.1
   url: https://repo.maven.apache.org/maven2/com/github/ben-manes/caffeine/caffeine/3.2.1/caffeine-3.2.1.jar
-  sha1: f5b6d9d584c6751ac8a7e89f1c33d9288f5247be
+  sha256: 771175b14f1f893856a901e81a4a76073c806f931102c6b23e6e41969a98a4a5
 - type: file
   dest: .m2/repository/com/github/ben-manes/caffeine/caffeine/3.2.1
   url: https://repo.maven.apache.org/maven2/com/github/ben-manes/caffeine/caffeine/3.2.1/caffeine-3.2.1.pom
-  sha1: 5ff7c31f713f451dd6ac042524128c636420eba9
+  sha256: 61805f651eb751433d8b969bd9c9e5680f7b96de4a36b0baaf379cd5801da3be
 - type: file
   dest: .m2/repository/com/github/cliftonlabs/json-simple/3.0.2
   url: https://repo.maven.apache.org/maven2/com/github/cliftonlabs/json-simple/3.0.2/json-simple-3.0.2.jar
-  sha1: 2337afdb06134a12fc0239299c3ceb2e9c209516
+  sha256: fda65a9ad0e1ac0c88987106e89aa4d8b2a2495e7e042371efa83813f65b7295
 - type: file
   dest: .m2/repository/com/github/cliftonlabs/json-simple/3.0.2
   url: https://repo.maven.apache.org/maven2/com/github/cliftonlabs/json-simple/3.0.2/json-simple-3.0.2.pom
-  sha1: 2056bb566483f7e1655359299353d41b1e2b631a
+  sha256: b0dacb1479cd4dbe0810d1aa335bf0fb9bc3c4ff55369c87597ba68f5879fe4f
 - type: file
   dest: .m2/repository/com/github/hypfvieh/dbus-java-core/4.3.1
   url: https://repo.maven.apache.org/maven2/com/github/hypfvieh/dbus-java-core/4.3.1/dbus-java-core-4.3.1.jar
-  sha1: b3b0a9193a29182518b073b027d4efafc5a21fbf
+  sha256: 3cd38632f86745707dc2c8b2cb630c59130cfa314eb7a488b4c19078bf417d54
 - type: file
   dest: .m2/repository/com/github/hypfvieh/dbus-java-core/4.3.1
   url: https://repo.maven.apache.org/maven2/com/github/hypfvieh/dbus-java-core/4.3.1/dbus-java-core-4.3.1.pom
-  sha1: ed0e6bb67854d010ad78873d4e2b5c76fd62d666
+  sha256: 20fe935bf804240211849e3816c1c47b4f4ffdca087ebd4698b4cc83454a45e7
 - type: file
   dest: .m2/repository/com/github/hypfvieh/dbus-java-parent/4.3.1
   url: https://repo.maven.apache.org/maven2/com/github/hypfvieh/dbus-java-parent/4.3.1/dbus-java-parent-4.3.1.pom
-  sha1: c1c66726375a3da7a51a332ba66ee1b7b2c569c2
+  sha256: 3a7a915f428910a2a5441f310dbd927e349906620713fe35198a7948d9f44dfe
 - type: file
   dest: .m2/repository/com/github/hypfvieh/dbus-java-transport-native-unixsocket/4.3.1
   url: https://repo.maven.apache.org/maven2/com/github/hypfvieh/dbus-java-transport-native-unixsocket/4.3.1/dbus-java-transport-native-unixsocket-4.3.1.jar
-  sha1: ef1bf3436c1a1be3a6cb886012848679ec64454c
+  sha256: f3f89827219b8b456f4fe244eee235a4ab90d6e4f889111d9e56d99377334c87
 - type: file
   dest: .m2/repository/com/github/hypfvieh/dbus-java-transport-native-unixsocket/4.3.1
   url: https://repo.maven.apache.org/maven2/com/github/hypfvieh/dbus-java-transport-native-unixsocket/4.3.1/dbus-java-transport-native-unixsocket-4.3.1.pom
-  sha1: d1efd1266d6a782652502965333720f0ba7fa150
+  sha256: 6eddda58c9e40a819b72e26d19c10fea03c6bcc503a3505b47658daada38d08a
 - type: file
   dest: .m2/repository/com/github/luben/zstd-jni/1.5.5-11
   url: https://repo.maven.apache.org/maven2/com/github/luben/zstd-jni/1.5.5-11/zstd-jni-1.5.5-11.jar
-  sha1: ca6ab366315e179dd80645aad4a60bab959c6523
+  sha256: d75b2ced6059f81ad23e021c554259b906b6c4f2991cb772409827569ead4c1a
 - type: file
   dest: .m2/repository/com/github/luben/zstd-jni/1.5.5-11
   url: https://repo.maven.apache.org/maven2/com/github/luben/zstd-jni/1.5.5-11/zstd-jni-1.5.5-11.pom
-  sha1: d394d7050319c1ebcc7b177a751a13645deff523
+  sha256: a0152b1897c4a6e7dd36e5f686f0e631c3839b5db208b38daa11a4f6dc9b25ff
 - type: file
   dest: .m2/repository/com/github/luben/zstd-jni/1.5.6-3
   url: https://repo.maven.apache.org/maven2/com/github/luben/zstd-jni/1.5.6-3/zstd-jni-1.5.6-3.jar
-  sha1: 823b794106e4bcb80110f49408d1641231f25927
+  sha256: f72ede1b39258faf81277dc58de30c71cbae4253732558d2ce10b53d8b5763d5
 - type: file
   dest: .m2/repository/com/github/luben/zstd-jni/1.5.6-3
   url: https://repo.maven.apache.org/maven2/com/github/luben/zstd-jni/1.5.6-3/zstd-jni-1.5.6-3.pom
-  sha1: 2f666dee96e782eee0dc6d4531452d2e92ce3fba
+  sha256: dfd2fa7b1d23939216902f844fa5e86a79cdfb9209760e4c04242b5a58d49490
 - type: file
   dest: .m2/repository/com/github/stephenc/jcip/jcip-annotations/1.0-1
   url: https://repo.maven.apache.org/maven2/com/github/stephenc/jcip/jcip-annotations/1.0-1/jcip-annotations-1.0-1.jar
-  sha1: ef31541dd28ae2cefdd17c7ebf352d93e9058c63
+  sha256: 4fccff8382aafc589962c4edb262f6aa595e34f1e11e61057d1c6a96e8fc7323
 - type: file
   dest: .m2/repository/com/github/stephenc/jcip/jcip-annotations/1.0-1
   url: https://repo.maven.apache.org/maven2/com/github/stephenc/jcip/jcip-annotations/1.0-1/jcip-annotations-1.0-1.pom
-  sha1: bdccebfbbbdd66fe56dcdf3bdee7b97a853cccc5
+  sha256: 68c2a5aa6e8f345743093e52b5b9e0190ba4d5a5215c0a59b4d7d33647208cbb
 - type: file
   dest: .m2/repository/com/github/virtuald/curvesapi/1.08
   url: https://repo.maven.apache.org/maven2/com/github/virtuald/curvesapi/1.08/curvesapi-1.08.jar
-  sha1: 3d3d36568154059825089b289dcfca481fe44e2c
+  sha256: ad95b08b8bbf9d7d17e5e00814898fa23324f32bc5b62f1a37801e6a56ce0079
 - type: file
   dest: .m2/repository/com/github/virtuald/curvesapi/1.08
   url: https://repo.maven.apache.org/maven2/com/github/virtuald/curvesapi/1.08/curvesapi-1.08.pom
-  sha1: 6be73cb9497beb1c595f6a8c1904cf0b07847625
+  sha256: 372e19ac518d58ce5ab553ca80388c7fe9920c5554d1362d18645a6ddbc5d126
 - type: file
   dest: .m2/repository/com/google/code/findbugs/jsr305/1.3.9
   url: https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9.pom
-  sha1: 67ea333a3244bc20a17d6f0c29498071dfa409fc
+  sha256: feab9191311c3d7aeef2b66d6064afc80d3d1d52d980fb07ae43c78c987ba93a
 - type: file
   dest: .m2/repository/com/google/code/findbugs/jsr305/3.0.2
   url: https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar
-  sha1: 25ea2e8b0c338a877313bd4672d3fe056ea78f0d
+  sha256: 766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7
 - type: file
   dest: .m2/repository/com/google/code/findbugs/jsr305/3.0.2
   url: https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.pom
-  sha1: 8d93cdf4d84d7e1de736df607945c6df0730a10f
+  sha256: 19889dbdf1b254b2601a5ee645b8147a974644882297684c798afe5d63d78dfe
 - type: file
   dest: .m2/repository/com/google/code/gson/gson/2.12.1
   url: https://repo.maven.apache.org/maven2/com/google/code/gson/gson/2.12.1/gson-2.12.1.jar
-  sha1: 4e773a317740b83b43cfc3d652962856041697cb
+  sha256: ebee13d5fb7477cd7f1cc010e0c356df8ca80709715248da97f79e35ccb4fbec
 - type: file
   dest: .m2/repository/com/google/code/gson/gson/2.12.1
   url: https://repo.maven.apache.org/maven2/com/google/code/gson/gson/2.12.1/gson-2.12.1.pom
-  sha1: d2c3993ff96e5da39a57e5e0b695eda560949b57
+  sha256: 0b5735ec85f45282f1e2c769779800427b150a8163f405093a9280b71cab1978
 - type: file
   dest: .m2/repository/com/google/code/gson/gson-parent/2.12.1
   url: https://repo.maven.apache.org/maven2/com/google/code/gson/gson-parent/2.12.1/gson-parent-2.12.1.pom
-  sha1: 660107b2e76095ef86bbd15c503afe11e5260bfb
+  sha256: c9e7b0b7e31be7be22684979c068001c652cb113c4e6ed894e39b643dee07fc1
 - type: file
   dest: .m2/repository/com/google/dagger/dagger/2.55
   url: https://repo.maven.apache.org/maven2/com/google/dagger/dagger/2.55/dagger-2.55.pom
-  sha1: cf1ab0f33907e08aa12bb7275b42e0c855b6692e
+  sha256: d17d162fb35c80a641ed62c0d56fedf2eb41cc5d06436c64e45a7ad82038fcda
 - type: file
   dest: .m2/repository/com/google/dagger/dagger/2.56.2
   url: https://repo.maven.apache.org/maven2/com/google/dagger/dagger/2.56.2/dagger-2.56.2.jar
-  sha1: 4fef38354b4edb764b1c4209a10fe4a5b84288d9
+  sha256: e016933f0cbd5fb9978739a4241f57e31525573db0d9b8aa9b7e72aadc54f33e
 - type: file
   dest: .m2/repository/com/google/dagger/dagger/2.56.2
   url: https://repo.maven.apache.org/maven2/com/google/dagger/dagger/2.56.2/dagger-2.56.2.pom
-  sha1: 71e36d8cd0ef0274efddc9a0bb7c2515b8246c28
+  sha256: 22341c621382ca5b83b12c3c671d1f59a4354a27db637060238b07d735a54231
 - type: file
   dest: .m2/repository/com/google/dagger/dagger-compiler/2.56.2
   url: https://repo.maven.apache.org/maven2/com/google/dagger/dagger-compiler/2.56.2/dagger-compiler-2.56.2.jar
-  sha1: 56ac74d364a7ee86eef677cc6b03d832ed871bff
+  sha256: 05054a73ea20041e3d6dc807bf7924f20f74fc68c64cc19bfc7f5fb9028bf68f
 - type: file
   dest: .m2/repository/com/google/dagger/dagger-compiler/2.56.2
   url: https://repo.maven.apache.org/maven2/com/google/dagger/dagger-compiler/2.56.2/dagger-compiler-2.56.2.pom
-  sha1: b71f1ad1171afe9060107a2c5272fd98b49e34a5
+  sha256: 34b12df495a7b222f92dd9dac2b1a28e111cd489f9efa1c0fb93753ad979c1c9
 - type: file
   dest: .m2/repository/com/google/dagger/dagger-spi/2.56.2
   url: https://repo.maven.apache.org/maven2/com/google/dagger/dagger-spi/2.56.2/dagger-spi-2.56.2.jar
-  sha1: c8dc7c5a0310b35a7bb06e296feed627c055b2d4
+  sha256: 14a7d83a113a07119adb65385f60d6f872b22aa4645b19fb5b18861fcab1a651
 - type: file
   dest: .m2/repository/com/google/dagger/dagger-spi/2.56.2
   url: https://repo.maven.apache.org/maven2/com/google/dagger/dagger-spi/2.56.2/dagger-spi-2.56.2.pom
-  sha1: 56669c3d1044e3a311be599f495177bfe47cd874
+  sha256: ffbaa5986ead4b211df3aacccefcfb344bd4203b27c547dad809a7904cb45712
 - type: file
   dest: .m2/repository/com/google/devtools/ksp/symbol-processing-api/2.1.10-1.0.31
   url: https://repo.maven.apache.org/maven2/com/google/devtools/ksp/symbol-processing-api/2.1.10-1.0.31/symbol-processing-api-2.1.10-1.0.31.jar
-  sha1: 24dd1b6db4490e16bbf763d110ffd99714477330
+  sha256: 3170c52186cb2096a47f538f09dd41e49ca1b3334d69ea83d6493d6f0365b7b4
 - type: file
   dest: .m2/repository/com/google/devtools/ksp/symbol-processing-api/2.1.10-1.0.31
   url: https://repo.maven.apache.org/maven2/com/google/devtools/ksp/symbol-processing-api/2.1.10-1.0.31/symbol-processing-api-2.1.10-1.0.31.pom
-  sha1: 5d363f0d8910b2bd6dacb00355880cd475469d00
+  sha256: 84988d29ea9688ba4e9a61cf9c7078bb47d3e65528f4870f7cd3613f8a4f5e62
 - type: file
   dest: .m2/repository/com/google/errorprone/error_prone_annotations/2.0.18
   url: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.0.18/error_prone_annotations-2.0.18.pom
-  sha1: 8e0351439081cc11563b09019302926addadaa25
+  sha256: 9144127192d6f612c2366825dceaeb23b0d53130b83e0bf1ffe107d1470a8487
 - type: file
   dest: .m2/repository/com/google/errorprone/error_prone_annotations/2.18.0
   url: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.18.0/error_prone_annotations-2.18.0.pom
-  sha1: 6d7bbfd3d7567e4c18e981a675ecda707e8a2db1
+  sha256: 920135797dcca5917b5a5c017642a58d340a4cd1bcd12f56f892a5663bd7bddc
 - type: file
   dest: .m2/repository/com/google/errorprone/error_prone_annotations/2.23.0
   url: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.23.0/error_prone_annotations-2.23.0.jar
-  sha1: 43a27853b6c7d54893e0b1997c2c778c347179eb
+  sha256: ec6f39f068b6ff9ac323c68e28b9299f8c0a80ca512dccb1d4a70f40ac3ec054
 - type: file
   dest: .m2/repository/com/google/errorprone/error_prone_annotations/2.23.0
   url: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.23.0/error_prone_annotations-2.23.0.pom
-  sha1: 6f1bf20af685aa25bd3cdb28bdaff06d4f09667a
+  sha256: d5abb17f231b63bf009358fa640281b744810cb9587e5994977834959c07dbd8
 - type: file
   dest: .m2/repository/com/google/errorprone/error_prone_annotations/2.36.0
   url: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.36.0/error_prone_annotations-2.36.0.pom
-  sha1: daf188a28315b31852ebd550f78f6b764972ee1f
+  sha256: d79cfd37c85f76d6b754c7501ee1dc8447b7b2642c2382d778252166bd331e9c
 - type: file
   dest: .m2/repository/com/google/errorprone/error_prone_annotations/2.38.0
   url: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.38.0/error_prone_annotations-2.38.0.jar
-  sha1: fc0ae991433e8590ba51cd558421478318a74c8c
+  sha256: 6661d5335090a5fc61dd869d2095bc6c1e2156e3aa47a6e4ababdf64c99a7889
 - type: file
   dest: .m2/repository/com/google/errorprone/error_prone_annotations/2.38.0
   url: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.38.0/error_prone_annotations-2.38.0.pom
-  sha1: 4afcfab3ddcad998e67cb7d8c30a748530834c69
+  sha256: 3007bef8aff3ae8ea12d81c3feacb4f15979b2cf5c3e38fc9189a98dea141167
 - type: file
   dest: .m2/repository/com/google/errorprone/error_prone_parent/2.0.18
   url: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.0.18/error_prone_parent-2.0.18.pom
-  sha1: 16ffdb67ed91d9d87a943a3127da3900d83cc81d
+  sha256: cf149955279b07d4f11e817985c1164a69e930d73db7441b43a6ef53bbd286c4
 - type: file
   dest: .m2/repository/com/google/errorprone/error_prone_parent/2.18.0
   url: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.18.0/error_prone_parent-2.18.0.pom
-  sha1: b1779a677965027cd2a3de91e61a80102086bb30
+  sha256: 47f22e99c7bf466391def16f8377985e5d3ba6f5bbcf65853644805513e15fad
 - type: file
   dest: .m2/repository/com/google/errorprone/error_prone_parent/2.23.0
   url: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.23.0/error_prone_parent-2.23.0.pom
-  sha1: 33b6b291ced282bf8a893828481cfe9d735e7b28
+  sha256: f5470a4b3104fe309fbe94a80d16c3c54d20f748f4c5de4f68a428688f30cbd4
 - type: file
   dest: .m2/repository/com/google/errorprone/error_prone_parent/2.36.0
   url: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.36.0/error_prone_parent-2.36.0.pom
-  sha1: f280159378f00e9f428f10887e22f84ebb2c7e9f
+  sha256: 3a4cfc8a6bed61eb48e969796fc31ea0d270b63e670599946a61883adb7094dc
 - type: file
   dest: .m2/repository/com/google/errorprone/error_prone_parent/2.38.0
   url: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.38.0/error_prone_parent-2.38.0.pom
-  sha1: c2bbf448e9e1c8ff4ac36e574a1040b7b5e8632d
+  sha256: e62458a6a3e63081bc7c57b3c0fac9f04f76ce32f606532db69fe2b3d47b934c
 - type: file
   dest: .m2/repository/com/google/errorprone/javac-shaded/9-dev-r4023-3
   url: https://repo.maven.apache.org/maven2/com/google/errorprone/javac-shaded/9-dev-r4023-3/javac-shaded-9-dev-r4023-3.jar
-  sha1: 72b688efd290280a0afde5f9892b0fde6f362d1d
+  sha256: 65bfccf60986c47fbc17c9ebab0be626afc41741e0a6ec7109e0768817a36f30
 - type: file
   dest: .m2/repository/com/google/errorprone/javac-shaded/9-dev-r4023-3
   url: https://repo.maven.apache.org/maven2/com/google/errorprone/javac-shaded/9-dev-r4023-3/javac-shaded-9-dev-r4023-3.pom
-  sha1: b3d5ccc3fff88a9f032b00c68372475d5875e7bc
+  sha256: 7459fd63c1e73770ca44d37a7a685b731a946eb7cd701ccb284dcb0ce6de3f88
 - type: file
   dest: .m2/repository/com/google/googlejavaformat/google-java-format/1.5
   url: https://repo.maven.apache.org/maven2/com/google/googlejavaformat/google-java-format/1.5/google-java-format-1.5.jar
-  sha1: fba7f130d29061d2d2ea384b4880c10cae92ef73
+  sha256: aa19ad7850fb85178aa22f2fddb163b84d6ce4d0035872f30d4408195ca1144e
 - type: file
   dest: .m2/repository/com/google/googlejavaformat/google-java-format/1.5
   url: https://repo.maven.apache.org/maven2/com/google/googlejavaformat/google-java-format/1.5/google-java-format-1.5.pom
-  sha1: cc2e4159240454885e348be497964eb6088ec2be
+  sha256: 994510ba3b16fb02e5ca17e8fd6158e2702fe95a1359c80be547b86b76a7aad5
 - type: file
   dest: .m2/repository/com/google/googlejavaformat/google-java-format-parent/1.5
   url: https://repo.maven.apache.org/maven2/com/google/googlejavaformat/google-java-format-parent/1.5/google-java-format-parent-1.5.pom
-  sha1: f4af62b0c1e9504c1f6a7b9f0ec5e2f92f8af2f7
+  sha256: 13aaf29158343f8b9c7dd7d3f58610290b05ad29ea69c7b9504869e47fbf6319
 - type: file
   dest: .m2/repository/com/google/guava/failureaccess/1.0.1
   url: https://repo.maven.apache.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.pom
-  sha1: e8160e78fdaaf7088621dc1649d9dd2dfcf8d0e8
+  sha256: e96042ce78fecba0da2be964522947c87b40a291b5fd3cd672a434924103c4b9
 - type: file
   dest: .m2/repository/com/google/guava/failureaccess/1.0.2
   url: https://repo.maven.apache.org/maven2/com/google/guava/failureaccess/1.0.2/failureaccess-1.0.2.jar
-  sha1: c4a06a64e650562f30b7bf9aaec1bfed43aca12b
+  sha256: 8a8f81cf9b359e3f6dfa691a1e776985c061ef2f223c9b2c80753e1b458e8064
 - type: file
   dest: .m2/repository/com/google/guava/failureaccess/1.0.2
   url: https://repo.maven.apache.org/maven2/com/google/guava/failureaccess/1.0.2/failureaccess-1.0.2.pom
-  sha1: 2df7ebe307b885a222be352d3bffd5fcf0428ad4
+  sha256: 19ebc6f4bdb4edbb3d07b6ee994f846b54ef295582a9b5634719ffa9f31d03b2
 - type: file
   dest: .m2/repository/com/google/guava/failureaccess/1.0.3
   url: https://repo.maven.apache.org/maven2/com/google/guava/failureaccess/1.0.3/failureaccess-1.0.3.pom
-  sha1: 12732d7aa78945d26029ab0dd54d5f824b6fe740
+  sha256: c54beff37f6d42d43e14722d54a522c9ad51ef97fc5b79277e62a3ebf882f3bb
 - type: file
   dest: .m2/repository/com/google/guava/guava/22.0
   url: https://repo.maven.apache.org/maven2/com/google/guava/guava/22.0/guava-22.0.pom
-  sha1: b87878db57d5cfc2ca7d3972cc8f7486bf02fbca
+  sha256: bfadb3b40f65dd6de1666d6b29f8bb54031396c76eeef4146cf9f28255f8bf33
 - type: file
   dest: .m2/repository/com/google/guava/guava/32.1.1-jre
   url: https://repo.maven.apache.org/maven2/com/google/guava/guava/32.1.1-jre/guava-32.1.1-jre.pom
-  sha1: 0e5cbc6d9046ce986b121a842f8d30ee6d81a900
+  sha256: 2c9071d7d1522b0c762057c34e8b9bfae39927a0eb755c36aa76519721870d7b
 - type: file
   dest: .m2/repository/com/google/guava/guava/33.0.0-jre
   url: https://repo.maven.apache.org/maven2/com/google/guava/guava/33.0.0-jre/guava-33.0.0-jre.jar
-  sha1: 161ba27964a62f241533807a46b8711b13c1d94b
+  sha256: f4d85c3e4d411694337cb873abea09b242b664bb013320be6105327c45991537
 - type: file
   dest: .m2/repository/com/google/guava/guava/33.0.0-jre
   url: https://repo.maven.apache.org/maven2/com/google/guava/guava/33.0.0-jre/guava-33.0.0-jre.pom
-  sha1: fe8e10972387557cdb729b11dd0e15349fecba14
+  sha256: fd70b14c441986c22e6d22ced2576787756be4918b145a8abd223e3a80b6e32d
 - type: file
   dest: .m2/repository/com/google/guava/guava/33.4.0-jre
   url: https://repo.maven.apache.org/maven2/com/google/guava/guava/33.4.0-jre/guava-33.4.0-jre.jar
-  sha1: 03fcc0a259f724c7de54a6a55ea7e26d3d5c0cac
+  sha256: b918c98a7e44dbe94ebd9fe3e40cddaadb5a93e6a78eb6008b42df237241e538
 - type: file
   dest: .m2/repository/com/google/guava/guava/33.4.0-jre
   url: https://repo.maven.apache.org/maven2/com/google/guava/guava/33.4.0-jre/guava-33.4.0-jre.pom
-  sha1: 5c671f0be7aa66b15ed0ec2e1afb4ee99c8c78e8
+  sha256: fa94db40022ddfc775af9ecfb130cce515b96f740daf82f20af846d95054134b
 - type: file
   dest: .m2/repository/com/google/guava/guava/33.4.8-jre
   url: https://repo.maven.apache.org/maven2/com/google/guava/guava/33.4.8-jre/guava-33.4.8-jre.pom
-  sha1: 1e4600093a822e9627c99eaaf7f58485089b2ffb
+  sha256: 04365d4b6ef22c8cf9349fe628069fc3e81a2c838351402ef4e95f9e757beebc
 - type: file
   dest: .m2/repository/com/google/guava/guava-parent/22.0
   url: https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/22.0/guava-parent-22.0.pom
-  sha1: 52822d0abaa6bc42a26ea0d26a83abad05d938a8
+  sha256: 1eaf9182e1977c1c50a70edbfbf70536398c68990bfaafc9f0e9899041201539
 - type: file
   dest: .m2/repository/com/google/guava/guava-parent/26.0-android
   url: https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/26.0-android/guava-parent-26.0-android.pom
-  sha1: a2c0df489614352b7e8e503e274bd1dee5c42a64
+  sha256: f8698ab46ca996ce889c1afc8ca4f25eb8ac6b034dc898d4583742360016cc04
 - type: file
   dest: .m2/repository/com/google/guava/guava-parent/32.1.1-jre
   url: https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/32.1.1-jre/guava-parent-32.1.1-jre.pom
-  sha1: 01c4a3f0686592f40c1052b273c9b533f6a71e6d
+  sha256: 06aa5d1ac068f2f809530f3ff53fb5c8c940152a253623d0b53c4f53f5a13a3d
 - type: file
   dest: .m2/repository/com/google/guava/guava-parent/33.0.0-jre
   url: https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/33.0.0-jre/guava-parent-33.0.0-jre.pom
-  sha1: 409239d054cf40f8a6b16afd2ff57f87f5b56a75
+  sha256: 040cc88c680b413d70ba9fc8371b36093021b10996aa3598621de767d418229a
 - type: file
   dest: .m2/repository/com/google/guava/guava-parent/33.4.0-android
   url: https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/33.4.0-android/guava-parent-33.4.0-android.pom
-  sha1: b58bc4ee7ad508a20cc41c776e8eef8fa78dfa5d
+  sha256: 7220ede61026596fbc720ee4b93246fa2d14f328058532b59ef053de397c7d83
 - type: file
   dest: .m2/repository/com/google/guava/guava-parent/33.4.0-jre
   url: https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/33.4.0-jre/guava-parent-33.4.0-jre.pom
-  sha1: ee79b87abc4ef9b3591db13c59de368c7b03dc79
+  sha256: 3a499ed34a0d9ee0f1bcc39230021a1cd4e2f7dd0426ab6844f585465d41dcd7
 - type: file
   dest: .m2/repository/com/google/guava/guava-parent/33.4.8-jre
   url: https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/33.4.8-jre/guava-parent-33.4.8-jre.pom
-  sha1: 59c58a0aeeae9d89b4ab534645dbffe7038843bf
+  sha256: a03c5199a1be14443df7fd40ba8673b1c6aae04deef6688ce7d573ea489e3a20
 - type: file
   dest: .m2/repository/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava
   url: https://repo.maven.apache.org/maven2/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
-  sha1: b421526c5f297295adef1c886e5246c39d4ac629
+  sha256: b372a037d4230aa57fbeffdef30fd6123f9c0c2db85d0aced00c91b974f33f99
 - type: file
   dest: .m2/repository/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava
   url: https://repo.maven.apache.org/maven2/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.pom
-  sha1: 1b77ba79f9b2b7dfd4e15ea7bb0d568d5eb9cb8d
+  sha256: 18d4b1db26153d4e55079ce1f76bb1fe05cdb862ef9954a88cbcc4ff38b8679b
 - type: file
   dest: .m2/repository/com/google/j2objc/j2objc-annotations/1.1
   url: https://repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.pom
-  sha1: b964a9414771661bdf35a3f10692a2fb0dd2c866
+  sha256: f0c98c571e93a7cb4dd18df0fa308f0963e7a0620ac2d4244e61e709d03ad6be
 - type: file
   dest: .m2/repository/com/google/j2objc/j2objc-annotations/2.8
   url: https://repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/2.8/j2objc-annotations-2.8.jar
-  sha1: c85270e307e7b822f1086b93689124b89768e273
+  sha256: f02a95fa1a5e95edb3ed859fd0fb7df709d121a35290eff8b74dce2ab7f4d6ed
 - type: file
   dest: .m2/repository/com/google/j2objc/j2objc-annotations/2.8
   url: https://repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/2.8/j2objc-annotations-2.8.pom
-  sha1: c8daacea97066c6826844e2175ec89857e598122
+  sha256: 37f87798b18385113c918bfa9e1276fe50735ef8fa849b5800c519d54dbf11f8
 - type: file
   dest: .m2/repository/com/google/j2objc/j2objc-annotations/3.0.0
   url: https://repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/3.0.0/j2objc-annotations-3.0.0.jar
-  sha1: 7399e65dd7e9ff3404f4535b2f017093bdb134c7
+  sha256: 88241573467ddca44ffd4d74aa04c2bbfd11bf7c17e0c342c94c9de7a70a7c64
 - type: file
   dest: .m2/repository/com/google/j2objc/j2objc-annotations/3.0.0
   url: https://repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/3.0.0/j2objc-annotations-3.0.0.pom
-  sha1: 45cbaa9d129a696907d1e5bc56c707b6a0043181
+  sha256: 23b3d039e168ad89dd114698e6dd7be383f4a2c577b8877d82c73a6515e74a17
 - type: file
   dest: .m2/repository/com/google/jimfs/jimfs/1.3.0
   url: https://repo.maven.apache.org/maven2/com/google/jimfs/jimfs/1.3.0/jimfs-1.3.0.jar
-  sha1: 93096472c3654a761c40c8e5d4ad82a7c1a0fd54
+  sha256: 82494408bb513f5512652e7b7f63d6f31f01eff57ce35c878644ffc2d25aee4f
 - type: file
   dest: .m2/repository/com/google/jimfs/jimfs/1.3.0
   url: https://repo.maven.apache.org/maven2/com/google/jimfs/jimfs/1.3.0/jimfs-1.3.0.pom
-  sha1: 7d23b20c9e2b0f66f8cfe594b53401f236959004
+  sha256: c47f2200810deecc2ef7ac6263a354a85eaf21fd54f6f18bbc738f514bfe70eb
 - type: file
   dest: .m2/repository/com/google/jimfs/jimfs-parent/1.3.0
   url: https://repo.maven.apache.org/maven2/com/google/jimfs/jimfs-parent/1.3.0/jimfs-parent-1.3.0.pom
-  sha1: 5a000ece6f0d01be73ddf4d6930767b802b68d7a
+  sha256: 1ee8cf6016feff978642baaf6a3676b140813460b4f0b2caba999a32ae5ea91e
 - type: file
   dest: .m2/repository/com/nimbusds/nimbus-jose-jwt/9.37.3
   url: https://repo.maven.apache.org/maven2/com/nimbusds/nimbus-jose-jwt/9.37.3/nimbus-jose-jwt-9.37.3.jar
-  sha1: 700f71ffefd60c16bd8ce711a956967ea9071cec
+  sha256: 12ae4a3a260095d7aeba2adea7ae396e8b9570db8b7b409e09a824c219cc0444
 - type: file
   dest: .m2/repository/com/nimbusds/nimbus-jose-jwt/9.37.3
   url: https://repo.maven.apache.org/maven2/com/nimbusds/nimbus-jose-jwt/9.37.3/nimbus-jose-jwt-9.37.3.pom
-  sha1: bf365bde37338a7aef7928b3a8fbaef259458213
+  sha256: afc63b689d881439b95f343b1dca750391edac63b87392be4d90d19c94ccafbe
 - type: file
   dest: .m2/repository/com/nulab-inc/zxcvbn/1.9.0
   url: https://repo.maven.apache.org/maven2/com/nulab-inc/zxcvbn/1.9.0/zxcvbn-1.9.0.jar
-  sha1: 47e0b80099d6109ef199072aaab326325aca5e44
+  sha256: 38efaebab09144eb1f4d4c9ff650e79df875a8d6c4539c105b079a606bb7db34
 - type: file
   dest: .m2/repository/com/nulab-inc/zxcvbn/1.9.0
   url: https://repo.maven.apache.org/maven2/com/nulab-inc/zxcvbn/1.9.0/zxcvbn-1.9.0.pom
-  sha1: 91336202f8faa8a6ab54df47f0c5a210a6798214
+  sha256: 1f95c7e0dac5a5f39d82b9ceca13029f8af61c45c6a5656b900a873b8b63864d
 - type: file
   dest: .m2/repository/com/squareup/javapoet/1.13.0
   url: https://repo.maven.apache.org/maven2/com/squareup/javapoet/1.13.0/javapoet-1.13.0.jar
-  sha1: d6562d385049f35eb50403fa86bb11cce76b866a
+  sha256: 4c7517e848a71b36d069d12bb3bf46a70fd4cda3105d822b0ed2e19c00b69291
 - type: file
   dest: .m2/repository/com/squareup/javapoet/1.13.0
   url: https://repo.maven.apache.org/maven2/com/squareup/javapoet/1.13.0/javapoet-1.13.0.pom
-  sha1: 17b682b96d0d2abfdd92f6a99fbab40dd4f4d360
+  sha256: 54a34fa8502a46bc90efdb49262600591fa80bf9a34f5a4c798311aec16ca977
 - type: file
   dest: .m2/repository/com/squareup/kotlinpoet/1.11.0
   url: https://repo.maven.apache.org/maven2/com/squareup/kotlinpoet/1.11.0/kotlinpoet-1.11.0.jar
-  sha1: 5a16322632c6361f7058c948bab1aafa6e7a337f
+  sha256: 2887ada1ca03dd83baa2758640d87e840d1907564db0ef88d2289c868a980492
 - type: file
   dest: .m2/repository/com/squareup/kotlinpoet/1.11.0
   url: https://repo.maven.apache.org/maven2/com/squareup/kotlinpoet/1.11.0/kotlinpoet-1.11.0.pom
-  sha1: 59af4a0ab542e124ba8de27050dbe91fe79ec36d
+  sha256: c30fae8d289e8a666b93fba205f25ac951493841ae146c0e35c35dcf6c4f892c
 - type: file
   dest: .m2/repository/com/thoughtworks/qdox/qdox/2.2.0
   url: https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/2.2.0/qdox-2.2.0.jar
-  sha1: 39651eb3ce73d6e506490ea352e1e13eab6b55e8
+  sha256: c260c3230b2340af97d54bf01f7f67ebc57c901922736c881bb11cb981302be2
 - type: file
   dest: .m2/repository/com/thoughtworks/qdox/qdox/2.2.0
   url: https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/2.2.0/qdox-2.2.0.pom
-  sha1: 5ffffaccce4c5176e48c661483f0dd22726e3cf8
+  sha256: c850fbad0b05eada85ca1bce22409a75f758aea0ca1e47a828c6a505ad361fab
 - type: file
   dest: .m2/repository/com/tobiasdiez/easybind/2.2
   url: https://repo.maven.apache.org/maven2/com/tobiasdiez/easybind/2.2/easybind-2.2.jar
-  sha1: f82970bea0731b8e4252bdae6d46dc5e205da2f3
+  sha256: 37cbca1b23e4d4910d4c49cba4640d7d12816941c1317b4e916db86b138ad6f1
 - type: file
   dest: .m2/repository/com/tobiasdiez/easybind/2.2
   url: https://repo.maven.apache.org/maven2/com/tobiasdiez/easybind/2.2/easybind-2.2.pom
-  sha1: e70da0540b4401fbb9c31fdc357c4cd59b0e98fe
+  sha256: f32a7b219c2daae2df40f548e2e10ffa8a953667e6c4c28988a11b237c672233
 - type: file
   dest: .m2/repository/com/zaxxer/SparseBitSet/1.3
   url: https://repo.maven.apache.org/maven2/com/zaxxer/SparseBitSet/1.3/SparseBitSet-1.3.jar
-  sha1: 533eac055afe3d5f614ea95e333afd6c2bde8f26
+  sha256: f76b85adb0c00721ae267b7cfde4da7f71d3121cc2160c9fc00c0c89f8c53c8a
 - type: file
   dest: .m2/repository/com/zaxxer/SparseBitSet/1.3
   url: https://repo.maven.apache.org/maven2/com/zaxxer/SparseBitSet/1.3/SparseBitSet-1.3.pom
-  sha1: f02d244fd072a051dc7bd34facc3e523b031af90
+  sha256: 118d67e345329a18dff4ebd1557f95f0c0ab4b4cb9d678749d666f9230001768
 - type: file
   dest: .m2/repository/commons-beanutils/commons-beanutils/1.8.3
   url: https://repo.maven.apache.org/maven2/commons-beanutils/commons-beanutils/1.8.3/commons-beanutils-1.8.3.pom
-  sha1: 2ac6e1903d8c7b7f739163408fedd15794faa81b
+  sha256: 552ad56800bc6010f1e6ea8c7638f24c74230e9991a52568df20d5b5aa5c4b20
 - type: file
   dest: .m2/repository/commons-beanutils/commons-beanutils/1.9.4
   url: https://repo.maven.apache.org/maven2/commons-beanutils/commons-beanutils/1.9.4/commons-beanutils-1.9.4.jar
-  sha1: d52b9abcd97f38c81342bb7e7ae1eee9b73cba51
+  sha256: 7d938c81789028045c08c065e94be75fc280527620d5bd62b519d5838532368a
 - type: file
   dest: .m2/repository/commons-beanutils/commons-beanutils/1.9.4
   url: https://repo.maven.apache.org/maven2/commons-beanutils/commons-beanutils/1.9.4/commons-beanutils-1.9.4.pom
-  sha1: 42e7c39331e1735250b294ce2984d0e434ebc955
+  sha256: c35cca7b61d4678d9578cbc0b901b8717b539abf9254441da78b8fe60de064d0
 - type: file
   dest: .m2/repository/commons-cli/commons-cli/1.4
   url: https://repo.maven.apache.org/maven2/commons-cli/commons-cli/1.4/commons-cli-1.4.jar
-  sha1: c51c00206bb913cd8612b24abd9fa98ae89719b1
+  sha256: fd3c7c9545a9cdb2051d1f9155c4f76b1e4ac5a57304404a6eedb578ffba7328
 - type: file
   dest: .m2/repository/commons-cli/commons-cli/1.4
   url: https://repo.maven.apache.org/maven2/commons-cli/commons-cli/1.4/commons-cli-1.4.pom
-  sha1: c5aed4264ff37247043f6dcb6613d994ea7f8473
+  sha256: f589bf30a98dc7497410b8eb8d86a167637577ac55cd5dd30cc4b57dbbc6f893
 - type: file
   dest: .m2/repository/commons-codec/commons-codec/1.11
   url: https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.11/commons-codec-1.11.jar
-  sha1: 3acb4705652e16236558f0f4f2192cc33c3bd189
+  sha256: e599d5318e97aa48f42136a2927e6dfa4e8881dff0e6c8e3109ddbbff51d7b7d
 - type: file
   dest: .m2/repository/commons-codec/commons-codec/1.11
   url: https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.11/commons-codec-1.11.pom
-  sha1: 093ee1760aba62d6896d578bd7d247d0fa52f0e7
+  sha256: c1e7140d1dea8fdf3528bc1e3c5444ac0b541297311f45f9806c213ec3ee9a10
 - type: file
   dest: .m2/repository/commons-codec/commons-codec/1.15
   url: https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.15/commons-codec-1.15.pom
-  sha1: c08f2dcdbba1a9466f3f9fa05e669fd61c3a47b7
+  sha256: c86ee198a35a3715487860f419cbf642e7e4d9e8714777947dbe6a4e3a20ab58
 - type: file
   dest: .m2/repository/commons-codec/commons-codec/1.16.1
   url: https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.16.1/commons-codec-1.16.1.jar
-  sha1: 47bd4d333fba53406f6c6c51884ddbca435c8862
+  sha256: ec87bfb55f22cbd1b21e2190eeda28b2b312ed2a431ee49fbdcc01812d04a5e4
 - type: file
   dest: .m2/repository/commons-codec/commons-codec/1.16.1
   url: https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.16.1/commons-codec-1.16.1.pom
-  sha1: fdca64157d8fd070e24bd7d4ae9b8851d9ed9c0e
+  sha256: b826ddd92f9d7cc64371a02fa0830c154d67c98370ea54a2d196e72eb590ad28
 - type: file
   dest: .m2/repository/commons-codec/commons-codec/1.17.0
   url: https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.17.0/commons-codec-1.17.0.jar
-  sha1: 0dbe8eef6e14460e73da07f7b11bf994d6626355
+  sha256: f700de80ac270d0344fdea7468201d8b9c805e5c648331c3619f2ee067ccfc59
 - type: file
   dest: .m2/repository/commons-codec/commons-codec/1.17.0
   url: https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.17.0/commons-codec-1.17.0.pom
-  sha1: 00df1652d86779f44021a4c52a928d0792217eec
+  sha256: c01c4cda5e408f41ed1d83e4a0a170cf53801b6338aba49f0f904786bc1214fc
 - type: file
   dest: .m2/repository/commons-collections/commons-collections/3.2.2
   url: https://repo.maven.apache.org/maven2/commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar
-  sha1: 8ad72fe39fa8c91eaaf12aadb21e0c3661fe26d5
+  sha256: eeeae917917144a68a741d4c0dff66aa5c5c5fd85593ff217bced3fc8ca783b8
 - type: file
   dest: .m2/repository/commons-collections/commons-collections/3.2.2
   url: https://repo.maven.apache.org/maven2/commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.pom
-  sha1: 02a5ba7cb070a882d2b7bd4bf5223e8e445c0268
+  sha256: d5d81fcc288c0d8c711c302007cada4aa9a226ed1a112d4baa64cb1d6322170b
 - type: file
   dest: .m2/repository/commons-digester/commons-digester/2.1
   url: https://repo.maven.apache.org/maven2/commons-digester/commons-digester/2.1/commons-digester-2.1.jar
-  sha1: 73a8001e7a54a255eef0f03521ec1805dc738ca0
+  sha256: e0b2b980a84fc6533c5ce291f1917b32c507f62bcad64198fff44368c2196a3d
 - type: file
   dest: .m2/repository/commons-digester/commons-digester/2.1
   url: https://repo.maven.apache.org/maven2/commons-digester/commons-digester/2.1/commons-digester-2.1.pom
-  sha1: 9e466a7b2c0d7abd4fe852bfc1ca44f729fd869e
+  sha256: 15a59c0e757c6c07c3d1b689d735c8e3a9ec5695d6ceb6a941d4062ab22901b7
 - type: file
   dest: .m2/repository/commons-io/commons-io/2.5
   url: https://repo.maven.apache.org/maven2/commons-io/commons-io/2.5/commons-io-2.5.pom
-  sha1: 7e39112810f6096061c43504188d18edc7d7eece
+  sha256: 28ebb2998bc7d7acb25078526971640892000f3413586ff42d611f1043bfec30
 - type: file
   dest: .m2/repository/commons-io/commons-io/2.6
   url: https://repo.maven.apache.org/maven2/commons-io/commons-io/2.6/commons-io-2.6.jar
-  sha1: 815893df5f31da2ece4040fe0a12fd44b577afaf
+  sha256: f877d304660ac2a142f3865badfc971dec7ed73c747c7f8d5d2f5139ca736513
 - type: file
   dest: .m2/repository/commons-io/commons-io/2.6
   url: https://repo.maven.apache.org/maven2/commons-io/commons-io/2.6/commons-io-2.6.pom
-  sha1: 5060835593e5b6ed18c82fc2e782f0a3c30a00b1
+  sha256: 0c23863893a2291f5a7afdbd8d15923b3948afd87e563fa341cdcf6eae338a60
 - type: file
   dest: .m2/repository/commons-io/commons-io/2.8.0
   url: https://repo.maven.apache.org/maven2/commons-io/commons-io/2.8.0/commons-io-2.8.0.pom
-  sha1: 9bde4473ef8c6f2e5aef5bc5fbf357663a90834e
+  sha256: d7c8641a37d6e76f36fb9e81fc1420e26a09d63fa32f00f74764de067ca8347d
 - type: file
   dest: .m2/repository/commons-io/commons-io/2.11.0
   url: https://repo.maven.apache.org/maven2/commons-io/commons-io/2.11.0/commons-io-2.11.0.jar
-  sha1: a2503f302b11ebde7ebc3df41daebe0e4eea3689
+  sha256: 961b2f6d87dbacc5d54abf45ab7a6e2495f89b75598962d8c723cea9bc210908
 - type: file
   dest: .m2/repository/commons-io/commons-io/2.11.0
   url: https://repo.maven.apache.org/maven2/commons-io/commons-io/2.11.0/commons-io-2.11.0.pom
-  sha1: 3fe5d6ebed1afb72c3e8c166dba0b0e00fdd1f16
+  sha256: 2e016fd7e3244b5f2c20acad834d93aa4790486ee1e4564641361a3e831eef59
 - type: file
   dest: .m2/repository/commons-io/commons-io/2.15.1
   url: https://repo.maven.apache.org/maven2/commons-io/commons-io/2.15.1/commons-io-2.15.1.pom
-  sha1: 3ec366b41f9e6c0f3f2c413299a0186ad6d093c4
+  sha256: 171a1af82b6759eb5740b3b8809aca80113deaf1153036f2f4445901dfd3f91d
 - type: file
   dest: .m2/repository/commons-io/commons-io/2.16.1
   url: https://repo.maven.apache.org/maven2/commons-io/commons-io/2.16.1/commons-io-2.16.1.jar
-  sha1: 377d592e740dc77124e0901291dbfaa6810a200e
+  sha256: f41f7baacd716896447ace9758621f62c1c6b0a91d89acee488da26fc477c84f
 - type: file
   dest: .m2/repository/commons-io/commons-io/2.16.1
   url: https://repo.maven.apache.org/maven2/commons-io/commons-io/2.16.1/commons-io-2.16.1.pom
-  sha1: 553d6f69e338060a231755afe0ebf99d14b45da6
+  sha256: 5777d292251c7895c04a4c57015683ec3b353a12486c9b3e7178e9b0b3c38fff
 - type: file
   dest: .m2/repository/commons-io/commons-io/2.17.0
   url: https://repo.maven.apache.org/maven2/commons-io/commons-io/2.17.0/commons-io-2.17.0.pom
-  sha1: af3aa19bcc67a14e5d0dad042e7d985f733cdff4
+  sha256: 484a939fff5310b8cb5c6b9029c2dcf155d3f93b8b8d6285f3f56bb2ba09fc49
 - type: file
   dest: .m2/repository/commons-io/commons-io/2.18.0
   url: https://repo.maven.apache.org/maven2/commons-io/commons-io/2.18.0/commons-io-2.18.0.jar
-  sha1: 44084ef756763795b31c578403dd028ff4a22950
+  sha256: f3ca0f8d63c40e23a56d54101c60d5edee136b42d84bfb85bc7963093109cf8b
 - type: file
   dest: .m2/repository/commons-io/commons-io/2.18.0
   url: https://repo.maven.apache.org/maven2/commons-io/commons-io/2.18.0/commons-io-2.18.0.pom
-  sha1: cbd7a6fd54081f8e3d2a90c3cb74a91a31662a86
+  sha256: 63d96941eb44df9c90d2adb2ad8c3f699c2e065e707045c5daf713fca52bcfca
 - type: file
   dest: .m2/repository/commons-logging/commons-logging/1.1.1
   url: https://repo.maven.apache.org/maven2/commons-logging/commons-logging/1.1.1/commons-logging-1.1.1.jar
-  sha1: 5043bfebc3db072ed80fbd362e7caf00e885d8ae
+  sha256: ce6f913cad1f0db3aad70186d65c5bc7ffcc9a99e3fe8e0b137312819f7c362f
 - type: file
   dest: .m2/repository/commons-logging/commons-logging/1.1.1
   url: https://repo.maven.apache.org/maven2/commons-logging/commons-logging/1.1.1/commons-logging-1.1.1.pom
-  sha1: 76672afb562b9e903674ad3a544cdf2092f1faa3
+  sha256: d0f2e16d054e8bb97add9ca26525eb2346f692809fcd2a28787da8ceb3c35ee8
 - type: file
   dest: .m2/repository/commons-logging/commons-logging/1.2
   url: https://repo.maven.apache.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2.jar
-  sha1: 4bfc12adfe4842bf07b657f0369c4cb522955686
+  sha256: daddea1ea0be0f56978ab3006b8ac92834afeefbd9b7e4e6316fca57df0fa636
 - type: file
   dest: .m2/repository/commons-logging/commons-logging/1.2
   url: https://repo.maven.apache.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2.pom
-  sha1: 075c03ba4b01932842a996ef8d3fc1ab61ddeac2
+  sha256: c91ab5aa570d86f6fd07cc158ec6bc2c50080402972ee9179fe24100739fbb20
 - type: file
   dest: .m2/repository/commons-validator/commons-validator/1.7
   url: https://repo.maven.apache.org/maven2/commons-validator/commons-validator/1.7/commons-validator-1.7.jar
-  sha1: 76069c915de3787f3ddd8726a56f47a95bfcbb0e
+  sha256: 4d74f4ce4fb68b2617edad086df6defdf9338467d2377d2c62e69038e1c4f02f
 - type: file
   dest: .m2/repository/commons-validator/commons-validator/1.7
   url: https://repo.maven.apache.org/maven2/commons-validator/commons-validator/1.7/commons-validator-1.7.pom
-  sha1: d84d250593bf1dd5c860803de9bb01de10d92c72
+  sha256: 533b417f674753f6c79fabfbfef96a463ea9c3cca3d7a83ff0eb7d7668293fc9
 - type: file
   dest: .m2/repository/de/swiesend/secret-service/2.0.1-alpha
   url: https://repo.maven.apache.org/maven2/de/swiesend/secret-service/2.0.1-alpha/secret-service-2.0.1-alpha.jar
-  sha1: 44f1c1de35ee80e97a51e6a739ae8690d99c0441
+  sha256: e75154a732c0653bce096f8689ec21e97f1be9ee10e876f94740b924505a5ca0
 - type: file
   dest: .m2/repository/de/swiesend/secret-service/2.0.1-alpha
   url: https://repo.maven.apache.org/maven2/de/swiesend/secret-service/2.0.1-alpha/secret-service-2.0.1-alpha.pom
-  sha1: 913ced8555f00d41ad4722f3b9d9c8bf251fb639
+  sha256: ec0f3631ea7bf8f51c7a9a3edee72d102cb950c26a71f90b397e893f2b270293
 - type: file
   dest: .m2/repository/io/airlift/airbase/112
   url: https://repo.maven.apache.org/maven2/io/airlift/airbase/112/airbase-112.pom
-  sha1: c095c49bfdd3c799855b110fb883542015055eaa
+  sha256: 18ccd104cbd97eb44bd57b68c047ab7ff81fbc800987f82d815c68ac4c2304ce
 - type: file
   dest: .m2/repository/io/airlift/aircompressor/0.27
   url: https://repo.maven.apache.org/maven2/io/airlift/aircompressor/0.27/aircompressor-0.27.jar
-  sha1: 5b3b5e7932a1d088ad1f13d109ffd688ab59ef9d
+  sha256: fdbef3137a28f63bb0cb93487803080ede746a4ec3d421e36c6f0c305c35e5e4
 - type: file
   dest: .m2/repository/io/airlift/aircompressor/0.27
   url: https://repo.maven.apache.org/maven2/io/airlift/aircompressor/0.27/aircompressor-0.27.pom
-  sha1: 8b95cebb315c4205633309d403c91c588c2a25c1
+  sha256: 5aacda89be38563bdf3bfac79333616c0802ca617070dea66ba649507c994441
 - type: file
   dest: .m2/repository/io/fabric8/kubernetes-client-bom/5.12.4
   url: https://repo.maven.apache.org/maven2/io/fabric8/kubernetes-client-bom/5.12.4/kubernetes-client-bom-5.12.4.pom
-  sha1: e79360b6c85f975006571e2251496c9677a15d19
+  sha256: d232392a89c3efdc85ab299c5a94e8b9dd35bc02f340ce8446ff659aa15913a0
 - type: file
   dest: .m2/repository/io/github/coffeelibs/tiny-oauth2-client/0.8.1
   url: https://repo.maven.apache.org/maven2/io/github/coffeelibs/tiny-oauth2-client/0.8.1/tiny-oauth2-client-0.8.1.jar
-  sha1: 0910b11bbcc5f2d1ab49a549bb1ac279ebd4c525
+  sha256: d21ecd5ac992a2751ca5c296e2a69aa6229bc797440408424eaeb4b244b06730
 - type: file
   dest: .m2/repository/io/github/coffeelibs/tiny-oauth2-client/0.8.1
   url: https://repo.maven.apache.org/maven2/io/github/coffeelibs/tiny-oauth2-client/0.8.1/tiny-oauth2-client-0.8.1.pom
-  sha1: c37b62fb770ca46041a302f0cbd04632b3c25fa8
+  sha256: e5e5d27411ee44300ee4e6c62c0bdce3d1574ce8009a161cb6121617dcd38d96
 - type: file
   dest: .m2/repository/io/netty/netty-bom/4.1.107.Final
   url: https://repo.maven.apache.org/maven2/io/netty/netty-bom/4.1.107.Final/netty-bom-4.1.107.Final.pom
-  sha1: 3eaa3b12c0e8140d40c9dc9aabcef31f4b2d320b
+  sha256: c36997558bfb4e11f200dda6ee2e41a45f2df9e1aef678eda08e79dd8938c210
 - type: file
   dest: .m2/repository/jakarta/inject/jakarta.inject-api/2.0.1
   url: https://repo.maven.apache.org/maven2/jakarta/inject/jakarta.inject-api/2.0.1/jakarta.inject-api-2.0.1.jar
-  sha1: 4c28afe1991a941d7702fe1362c365f0a8641d1e
+  sha256: f7dc98062fccf14126abb751b64fab12c312566e8cbdc8483598bffcea93af7c
 - type: file
   dest: .m2/repository/jakarta/inject/jakarta.inject-api/2.0.1
   url: https://repo.maven.apache.org/maven2/jakarta/inject/jakarta.inject-api/2.0.1/jakarta.inject-api-2.0.1.pom
-  sha1: d53e5e2c5362dc3f6748efac10909af8562b3505
+  sha256: e7fd7232e96307a575b2494c9367d68cf43ec98244aace3ccc23e1773ffa6fda
 - type: file
   dest: .m2/repository/jakarta/inject/jakarta.inject-api/2.0.1.MR
   url: https://repo.maven.apache.org/maven2/jakarta/inject/jakarta.inject-api/2.0.1.MR/jakarta.inject-api-2.0.1.MR.pom
-  sha1: 7544d913db686a4a7fe8057cba278371c5c483f9
+  sha256: d760f3a614fcdcb0a86ce4987a76a12c4646d220a71e66177126614d45356f59
 - type: file
   dest: .m2/repository/jakarta/platform/jakarta.jakartaee-bom/9.1.0
   url: https://repo.maven.apache.org/maven2/jakarta/platform/jakarta.jakartaee-bom/9.1.0/jakarta.jakartaee-bom-9.1.0.pom
-  sha1: 39a915229cabfe6bba43e0566b1a74bf8fe3eefe
+  sha256: df98e0266219fdbb82562826d79a3a20776a8ba02aa787f0f0765a538654c8a4
 - type: file
   dest: .m2/repository/jakarta/platform/jakartaee-api-parent/9.1.0
   url: https://repo.maven.apache.org/maven2/jakarta/platform/jakartaee-api-parent/9.1.0/jakartaee-api-parent-9.1.0.pom
-  sha1: e5020a636b3c0cc4c5dd110e17213aaded1d6895
+  sha256: a7702c487026802784b5797b62330a8b8d6592bf0f4737b25c67a5eac82659c0
 - type: file
   dest: .m2/repository/javax/inject/javax.inject/1
   url: https://repo.maven.apache.org/maven2/javax/inject/javax.inject/1/javax.inject-1.jar
-  sha1: 6975da39a7040257bd51d21a231b76c915872d38
+  sha256: 91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff
 - type: file
   dest: .m2/repository/javax/inject/javax.inject/1
   url: https://repo.maven.apache.org/maven2/javax/inject/javax.inject/1/javax.inject-1.pom
-  sha1: b8e00a8a0deb0ebef447570e37ff8146ccd92cbe
+  sha256: 943e12b100627804638fa285805a0ab788a680266531e650921ebfe4621a8bfa
 - type: file
   dest: .m2/repository/log4j/log4j/1.2.16
   url: https://repo.maven.apache.org/maven2/log4j/log4j/1.2.16/log4j-1.2.16.pom
-  sha1: 88efb1b8d3d993fe339e9e2b201c75eed57d4c65
+  sha256: 2b1e9f1055cf0b4a4659aaf474b65e842d5c1dc580b5c4e0238ef63470d110fd
 - type: file
   dest: .m2/repository/me/fabriciorby/maven-surefire-junit5-tree-reporter/1.4.0
   url: https://repo.maven.apache.org/maven2/me/fabriciorby/maven-surefire-junit5-tree-reporter/1.4.0/maven-surefire-junit5-tree-reporter-1.4.0.jar
-  sha1: 19ee66eef77899dec24c5b3f562c470666519b66
+  sha256: 468774d3b95e34873032d46333c81f515dd7f7ae47a872c3f269e67f3f991ad7
 - type: file
   dest: .m2/repository/me/fabriciorby/maven-surefire-junit5-tree-reporter/1.4.0
   url: https://repo.maven.apache.org/maven2/me/fabriciorby/maven-surefire-junit5-tree-reporter/1.4.0/maven-surefire-junit5-tree-reporter-1.4.0.pom
-  sha1: 584779d371c1f6989a154125a10cbda1f5c80640
+  sha256: 80ae85c82a2fdcdd8fa21004b7b35f3f98528eb1b849cf5e29cce7d809d13a16
 - type: file
   dest: .m2/repository/net/bytebuddy/byte-buddy/1.17.5
   url: https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy/1.17.5/byte-buddy-1.17.5.jar
-  sha1: 88450f120903b7e72470462cdbd2b75a3842223c
+  sha256: 71568c9f8396677219f650268fbf6493ded484edcdbdf2dae6129ca5be81e8db
 - type: file
   dest: .m2/repository/net/bytebuddy/byte-buddy/1.17.5
   url: https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy/1.17.5/byte-buddy-1.17.5.pom
-  sha1: d734db57edaed464db809abc3a43a1442836fb9f
+  sha256: 53cd43dbb35b48e44725cd576d2006e1f71f21687d040f780cc70a0a7efd41c2
 - type: file
   dest: .m2/repository/net/bytebuddy/byte-buddy-agent/1.17.5
   url: https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy-agent/1.17.5/byte-buddy-agent-1.17.5.jar
-  sha1: 58f9507f5f28d1d3e7adfb4ec2fe37c29d332c9b
+  sha256: c5b9334ad82e632f6af60df22bbbdbbb62cee04877f4f43c38ba04aed9bd9901
 - type: file
   dest: .m2/repository/net/bytebuddy/byte-buddy-agent/1.17.5
   url: https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy-agent/1.17.5/byte-buddy-agent-1.17.5.pom
-  sha1: d1a94980a899355cd65ee4d8df9d4482ccccca83
+  sha256: 0b83482fb523b5bf9474aa82a7c5d3ce13cf3a5a9ab5d63ace955919f6d7cc14
 - type: file
   dest: .m2/repository/net/bytebuddy/byte-buddy-parent/1.17.5
   url: https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy-parent/1.17.5/byte-buddy-parent-1.17.5.pom
-  sha1: a0a8d4ae950cec98001cbeb081d7fcde0c309210
+  sha256: 1e8375827ee7d2f5e4c70cb31c9167ecec60693cf6a5b773a1e66fd4d2675367
 - type: file
   dest: .m2/repository/net/ltgt/gradle/incap/incap/0.2
   url: https://repo.maven.apache.org/maven2/net/ltgt/gradle/incap/incap/0.2/incap-0.2.jar
-  sha1: 0c73e3db9bee414d6ee27995d951fcdbee09acad
+  sha256: b625b9806b0f1e4bc7a2e3457119488de3cd57ea20feedd513db070a573a4ffd
 - type: file
   dest: .m2/repository/net/ltgt/gradle/incap/incap/0.2
   url: https://repo.maven.apache.org/maven2/net/ltgt/gradle/incap/incap/0.2/incap-0.2.pom
-  sha1: 31eb7a3f96dc655b77185ca2f6c8b39a8d9fedb3
+  sha256: 1a4a08a1e88d32052cd82dc2f740b34d3048e2c0e6a7c2bfe2309ed00771f73a
 - type: file
   dest: .m2/repository/net/rootdev/java-rdfa/0.4.2
   url: https://repo.maven.apache.org/maven2/net/rootdev/java-rdfa/0.4.2/java-rdfa-0.4.2.jar
-  sha1: 83009cabe2029f1e07f564e509634b7c168b7c7a
+  sha256: c0eea08a02e4ea61e57393a589a2fda39480e6f825d503534e79aeb1c17c6b7d
 - type: file
   dest: .m2/repository/net/rootdev/java-rdfa/0.4.2
   url: https://repo.maven.apache.org/maven2/net/rootdev/java-rdfa/0.4.2/java-rdfa-0.4.2.pom
-  sha1: a125716d5760b3d351206d5b7366fa249e9021e2
+  sha256: 3b76fc3bb586498a57636461c6d22751c74a70bab8af9371c2d10cc180a8d69e
 - type: file
   dest: .m2/repository/net/rootdev/java-rdfa-parent/0.4.2
   url: https://repo.maven.apache.org/maven2/net/rootdev/java-rdfa-parent/0.4.2/java-rdfa-parent-0.4.2.pom
-  sha1: b8c4b5cb4fbed25956b67f3d17d7bf4334127575
+  sha256: 0e2ce66730e9a5e4b3f9323678c658e6f26e17f21cfa7ad9454e4239a9eaed06
 - type: file
   dest: .m2/repository/org/apache/apache/4
   url: https://repo.maven.apache.org/maven2/org/apache/apache/4/apache-4.pom
-  sha1: 602b647986c1d24301bc3d70e5923696bc7f1401
+  sha256: 9e9323a26ba8eb2394efef0c96d31b70df570808630dc147cab1e73541cc5194
 - type: file
   dest: .m2/repository/org/apache/apache/6
   url: https://repo.maven.apache.org/maven2/org/apache/apache/6/apache-6.pom
-  sha1: 70e78921afc16d914e65611d18ab1b2d6cb20e57
+  sha256: 12edb5096e13f40c362d0bd40902589fa9586505123fa26799ce50b116fa5bb3
 - type: file
   dest: .m2/repository/org/apache/apache/7
   url: https://repo.maven.apache.org/maven2/org/apache/apache/7/apache-7.pom
-  sha1: a5f679b14bb06a3cb3769eb04e228c8b9e12908f
+  sha256: 1397ce1db433adc9f223dbf07496d133681448751f4ae29e58f68e78fb4b6c25
 - type: file
   dest: .m2/repository/org/apache/apache/9
   url: https://repo.maven.apache.org/maven2/org/apache/apache/9/apache-9.pom
-  sha1: de55d73a30c7521f3d55e8141d360ffbdfd88caa
+  sha256: 4946e60a547c8eda69f3bc23c5b6f0dadcf8469ea49b1d1da7de34aecfcf18dd
 - type: file
   dest: .m2/repository/org/apache/apache/10
   url: https://repo.maven.apache.org/maven2/org/apache/apache/10/apache-10.pom
-  sha1: 48296e511366fa13aad48c58d8e09721774abec6
+  sha256: 802feece72852dafcbd0a425a60367c72c5cb9b6ea5aae59481128569189daf9
 - type: file
   dest: .m2/repository/org/apache/apache/13
   url: https://repo.maven.apache.org/maven2/org/apache/apache/13/apache-13.pom
-  sha1: 15aff1faaec4963617f07dbe8e603f0adabc3a12
+  sha256: ff513db0361fd41237bef4784968bc15aae478d4ec0a9496f811072ccaf3841d
 - type: file
   dest: .m2/repository/org/apache/apache/16
   url: https://repo.maven.apache.org/maven2/org/apache/apache/16/apache-16.pom
-  sha1: 8a90e31780e5cd0685ccaf25836c66e3b4e163b7
+  sha256: 9f85ff2fd7d6cb3097aa47fb419ee7f0ebe869109f98aba9f4eca3f49e74a40e
 - type: file
   dest: .m2/repository/org/apache/apache/18
   url: https://repo.maven.apache.org/maven2/org/apache/apache/18/apache-18.pom
-  sha1: bd408bbea3840f2c7f914b29403e39a90f84fd5f
+  sha256: 7831307285fd475bbc36b20ae38e7882f11c3153b1d5930f852d44eda8f33c17
 - type: file
   dest: .m2/repository/org/apache/apache/19
   url: https://repo.maven.apache.org/maven2/org/apache/apache/19/apache-19.pom
-  sha1: db8bb0231dcbda5011926dbaca1a7ce652fd5517
+  sha256: 91f7a33096ea69bac2cbaf6d01feb934cac002c48d8c8cfa9c240b40f1ec21df
 - type: file
   dest: .m2/repository/org/apache/apache/21
   url: https://repo.maven.apache.org/maven2/org/apache/apache/21/apache-21.pom
-  sha1: 649b700a1b2b4a1d87e7ae8e3f47bfe101b2a4a5
+  sha256: af10c108da014f17cafac7b52b2b4b5a3a1c18265fa2af97a325d9143537b380
 - type: file
   dest: .m2/repository/org/apache/apache/23
   url: https://repo.maven.apache.org/maven2/org/apache/apache/23/apache-23.pom
-  sha1: 0404949e96725e63a10a6d8f9d9b521948d170d5
+  sha256: bc10624e0623f36577fac5639ca2936d3240ed152fb6d8d533ab4d270543491c
 - type: file
   dest: .m2/repository/org/apache/apache/25
   url: https://repo.maven.apache.org/maven2/org/apache/apache/25/apache-25.pom
-  sha1: c2202b94ed7980d47f78ab7850ee981fd69ba7e2
+  sha256: e68fc19a48cec582a6732fd0b10dbfe9feca25060963def89e547f8a3759d379
 - type: file
   dest: .m2/repository/org/apache/apache/26
   url: https://repo.maven.apache.org/maven2/org/apache/apache/26/apache-26.pom
-  sha1: d05aaef85ff7d6ddf4e5c8770046c006cb66795a
+  sha256: 765b9c71832d2faad9611869c1f07263e3dfd000ebefdcd434d1f14cb2be3ea1
 - type: file
   dest: .m2/repository/org/apache/apache/29
   url: https://repo.maven.apache.org/maven2/org/apache/apache/29/apache-29.pom
-  sha1: 57991491045c9a37a3113f24bf29a41a4ceb1459
+  sha256: 3e49037174820bbd0df63420a977255886398954c2a06291fa61f727ac35b377
 - type: file
   dest: .m2/repository/org/apache/apache/30
   url: https://repo.maven.apache.org/maven2/org/apache/apache/30/apache-30.pom
-  sha1: 8ec9c23c01b89c7c704fea3fc4822c4de4c02430
+  sha256: 63dd4a393a9c0dfcb314efe83871a41d243bc8d200cbc7f2d197f30da78239d8
 - type: file
   dest: .m2/repository/org/apache/apache/31
   url: https://repo.maven.apache.org/maven2/org/apache/apache/31/apache-31.pom
-  sha1: 9009cbdad2b69835f2df9265794c8ab50cf4dce1
+  sha256: 555d0c9eaa69c042aff924927b9381e8f8174136d355eead445224452e6291cc
 - type: file
   dest: .m2/repository/org/apache/apache/32
   url: https://repo.maven.apache.org/maven2/org/apache/apache/32/apache-32.pom
-  sha1: 2e08f841a6fbc946452701faaf5e39a17ac97ef3
+  sha256: cfd872c0ec27f53ae68f43dbc0fecded8add773079a53afbd390e407b42ce72f
 - type: file
   dest: .m2/repository/org/apache/apache/33
   url: https://repo.maven.apache.org/maven2/org/apache/apache/33/apache-33.pom
-  sha1: f7b7b5a9e84395f17d7e6a136e5bfc4b9973566d
+  sha256: d78bd8524c5f8380a190a6525686629a95dfe512df21111383a6d8c0923a4415
 - type: file
   dest: .m2/repository/org/apache/apache/34
   url: https://repo.maven.apache.org/maven2/org/apache/apache/34/apache-34.pom
-  sha1: af0993d3a3e77c5e48a05983bf54d9ed19315aa0
+  sha256: 3671ae9d4d062ae3bb985731c76088bb2f6f7d7254e2d304ee9f690b97651328
 - type: file
   dest: .m2/repository/org/apache/commons/commons-collections4/4.4
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-collections4/4.4/commons-collections4-4.4.jar
-  sha1: 62ebe7544cb7164d87e0637a2a6a2bdc981395e8
+  sha256: 1df8b9430b5c8ed143d7815e403e33ef5371b2400aadbe9bda0883762e0846d1
 - type: file
   dest: .m2/repository/org/apache/commons/commons-collections4/4.4
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-collections4/4.4/commons-collections4-4.4.pom
-  sha1: 05428d42492ca170947632194080eb9432fbdf6c
+  sha256: 271bd673839af46e73aff957e2918d4bf96f5ac4f6c6cf4d5be93fd1f1271c4d
 - type: file
   dest: .m2/repository/org/apache/commons/commons-compress/1.20
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.20/commons-compress-1.20.pom
-  sha1: a63d6a48347a2848f6a798c9efad976829011f7c
+  sha256: d95678e3af56b17c7db6cff9645efad5eb59be9f3c1caaaf5f0146edf04691d7
 - type: file
   dest: .m2/repository/org/apache/commons/commons-compress/1.26.1
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.26.1/commons-compress-1.26.1.jar
-  sha1: 44331c1130c370e726a2e1a3e6fba6d2558ef04a
+  sha256: 27bb5d40f37c3bb7205b4a0540247df057715e9f6cbbd97d626ab8b50318bb04
 - type: file
   dest: .m2/repository/org/apache/commons/commons-compress/1.26.1
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.26.1/commons-compress-1.26.1.pom
-  sha1: 1f7f7a9f3acd67344c3ae0e64d6fc66a61b9b1b4
+  sha256: 5f448a021d88c96f3840dfe619128d62e5cfb62712cd6e66dca8a7704945b06e
 - type: file
   dest: .m2/repository/org/apache/commons/commons-compress/1.26.2
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.26.2/commons-compress-1.26.2.jar
-  sha1: eb1f823447af685208e684fce84783b43517960c
+  sha256: 9168a03141d8fc7eda21a2360d83cc0412bcbb1d6204d992bd48c2573cb3c6b8
 - type: file
   dest: .m2/repository/org/apache/commons/commons-compress/1.26.2
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.26.2/commons-compress-1.26.2.pom
-  sha1: 0d9cae57ca05e437e0adb7f26f86160049c649c4
+  sha256: 1428719895cd0a913aee33e2424b9a804b10f1197e5d35a9ce99cf2a1174cb0e
 - type: file
   dest: .m2/repository/org/apache/commons/commons-csv/1.8
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-csv/1.8/commons-csv-1.8.jar
-  sha1: 037ca9a9aa2d4be2599e55506a6d3170dd7a3df4
+  sha256: a8bd56652ed4668d9d5a33994ae52f59b9e39c8eb0ebcb6684e68aeee7579a61
 - type: file
   dest: .m2/repository/org/apache/commons/commons-csv/1.8
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-csv/1.8/commons-csv-1.8.pom
-  sha1: 3ddd274b60d20b9dcad0eccf05103854c4fb44e4
+  sha256: 5c51343cf00293225e5e11f03553b2b89785cbfb82196626c55d8a7261626934
 - type: file
   dest: .m2/repository/org/apache/commons/commons-digester3/3.2
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-digester3/3.2/commons-digester3-3.2.jar
-  sha1: c3f68c5ff25ec5204470fd8fdf4cb8feff5e8a79
+  sha256: 1c150e3d2df4b4237b47e28fea2079fb0da324578d5cca6a5fed2e37a62082ec
 - type: file
   dest: .m2/repository/org/apache/commons/commons-digester3/3.2
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-digester3/3.2/commons-digester3-3.2.pom
-  sha1: 2665d95cf45b9341640df0223d59c87aa5082855
+  sha256: 5bb8a198adb597c30204b4f1c336fdb3d2816536403e9ad3349ab200032e5445
 - type: file
   dest: .m2/repository/org/apache/commons/commons-lang3/3.10
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.10/commons-lang3-3.10.pom
-  sha1: 4043acd9e0e444b2c10b609fefcb02bcfc4b3b8b
+  sha256: 005b5a3a88736bd2584f69cc59467e67c106e6a4b7a2dbd1ba2251267e96011d
 - type: file
   dest: .m2/repository/org/apache/commons/commons-lang3/3.11
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.11/commons-lang3-3.11.pom
-  sha1: ae77f78f72fe868bc33968df9ef5fbc0beae8a02
+  sha256: 980d665d83fed04665134f0578e507442a0e750691073784391b0a7988724a75
 - type: file
   dest: .m2/repository/org/apache/commons/commons-lang3/3.12.0
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar
-  sha1: c6842c86792ff03b9f1d1fe2aab8dc23aa6c6f0e
+  sha256: d919d904486c037f8d193412da0c92e22a9fa24230b9d67a57855c5c31c7e94e
 - type: file
   dest: .m2/repository/org/apache/commons/commons-lang3/3.12.0
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.pom
-  sha1: 302d01a9279f7a400b1e767be60f12c02a5cf513
+  sha256: 82d31f1dcc4583effd744e979165b16da64bf86bca623fc5d1b03ed94f45c85a
 - type: file
   dest: .m2/repository/org/apache/commons/commons-lang3/3.14.0
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.14.0/commons-lang3-3.14.0.jar
-  sha1: 1ed471194b02f2c6cb734a0cd6f6f107c673afae
+  sha256: 7b96bf3ee68949abb5bc465559ac270e0551596fa34523fddf890ec418dde13c
 - type: file
   dest: .m2/repository/org/apache/commons/commons-lang3/3.14.0
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.14.0/commons-lang3-3.14.0.pom
-  sha1: 063304d0daef2181ff359107bc29fb865a04d3cf
+  sha256: 110438863bad37c28f906bf87016e38c7a8c758ba321e09d11dc5a2363a8e79e
 - type: file
   dest: .m2/repository/org/apache/commons/commons-lang3/3.17.0
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.17.0/commons-lang3-3.17.0.jar
-  sha1: b17d2136f0460dcc0d2016ceefca8723bdf4ee70
+  sha256: 6ee731df5c8e5a2976a1ca023b6bb320ea8d3539fbe64c8a1d5cb765127c33b4
 - type: file
   dest: .m2/repository/org/apache/commons/commons-lang3/3.17.0
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.17.0/commons-lang3-3.17.0.pom
-  sha1: 967463be2b7350cef4fe4c1dac443a4a333a3be1
+  sha256: 351c6e4940e939b1f330df47f60f13ba383db81ee008181af541f3a2a6d2a56c
 - type: file
   dest: .m2/repository/org/apache/commons/commons-math3/3.6.1
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar
-  sha1: e4ba98f1d4b3c80ec46392f25e094a6a2e58fcbf
+  sha256: 1e56d7b058d28b65abd256b8458e3885b674c1d588fa43cd7d1cbb9c7ef2b308
 - type: file
   dest: .m2/repository/org/apache/commons/commons-math3/3.6.1
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.pom
-  sha1: d0ee0ddf185d57393ae8fb5cc28bba6efff7389c
+  sha256: fad72336ea7d7dd06da103144e3740db508fa4b17d9c54d7847737edc24a7e60
 - type: file
   dest: .m2/repository/org/apache/commons/commons-parent/5
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/5/commons-parent-5.pom
-  sha1: a0a168281558e7ae972f113fa128bc46b4973edd
+  sha256: 8bd632c00bdf80a7de36c22b60f12452c147d8eca2f00d79d66699ebe7daa02a
 - type: file
   dest: .m2/repository/org/apache/commons/commons-parent/14
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/14/commons-parent-14.pom
-  sha1: f2d3a6ada0e1cad7236e1f2a06ec5d4c811f3681
+  sha256: 24f2e52bde65e2dc9cfcebb2fc22d8de0edb3726925ccf80b13db4eeb515a302
 - type: file
   dest: .m2/repository/org/apache/commons/commons-parent/17
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/17/commons-parent-17.pom
-  sha1: 84bc2f457fac92c947cde9c15c81786ded79b3c1
+  sha256: 96e718baf534874ee62ce4d42de265f2ddacd88391a540e030d59d98fa7c4408
 - type: file
   dest: .m2/repository/org/apache/commons/commons-parent/22
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/22/commons-parent-22.pom
-  sha1: 0e895fa7ed472b3b2081ef77e2d5ece78c139d54
+  sha256: fb8c5e55e30a7addb4ff210858a0e8d2494ed6757bbe19012da99d51586c3cbb
 - type: file
   dest: .m2/repository/org/apache/commons/commons-parent/34
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/34/commons-parent-34.pom
-  sha1: 1f6be162a806d8343e3cd238dd728558532473a5
+  sha256: 3a2e69d06d641d1f3b293126dc9e2e4ea6563bf8c36c87e0ab6fa4292d04b79c
 - type: file
   dest: .m2/repository/org/apache/commons/commons-parent/39
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/39/commons-parent-39.pom
-  sha1: 4bc32d3cda9f07814c548492af7bf19b21798d46
+  sha256: 87cd27e1a02a5c3eb6d85059ce98696bb1b44c2b8b650f0567c86df60fa61da7
 - type: file
   dest: .m2/repository/org/apache/commons/commons-parent/42
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/42/commons-parent-42.pom
-  sha1: 35d45eda74fe511d3d60b68e1dac29ed55043354
+  sha256: cd313494c670b483ec256972af1698b330e598f807002354eb765479f604b09c
 - type: file
   dest: .m2/repository/org/apache/commons/commons-parent/47
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/47/commons-parent-47.pom
-  sha1: 391715f2f4f1b32604a201a2f4ea74a174e1f21c
+  sha256: 8a8ecb570553bf9f1ffae211a8d4ca9ee630c17afe59293368fba7bd9b42fcb7
 - type: file
   dest: .m2/repository/org/apache/commons/commons-parent/48
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/48/commons-parent-48.pom
-  sha1: 1cdeb626cf4f0cec0f171ec838a69922efc6ef95
+  sha256: 1e1f7de9370a7b7901f128f1dacd1422be74e3f47f9558b0f79e04c0637ca0b4
 - type: file
   dest: .m2/repository/org/apache/commons/commons-parent/50
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/50/commons-parent-50.pom
-  sha1: b47c55b7ee647e1c78546791e7f4fe59b842c320
+  sha256: 7b7a2db3f747074b5867f553d5efc8072be26ede32879d052c347e7c81117f06
 - type: file
   dest: .m2/repository/org/apache/commons/commons-parent/51
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/51/commons-parent-51.pom
-  sha1: 2f1f8c26ad5602fdff6c3f95f38887943cd68470
+  sha256: 9b779d18b22d8de559605558e7bb0a0a31b3f00c2abb9c878117c398aacabeca
 - type: file
   dest: .m2/repository/org/apache/commons/commons-parent/52
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/52/commons-parent-52.pom
-  sha1: 004ee86dedc66d0010ccdc29e5a4ce014c057854
+  sha256: 75dbe8f34e98e4c3ff42daae4a2f9eb4cbcd3b5f1047d54460ace906dbb4502e
 - type: file
   dest: .m2/repository/org/apache/commons/commons-parent/64
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/64/commons-parent-64.pom
-  sha1: aec2c7e06fc7ab9271cd4d076e8251df6a0d55da
+  sha256: 6f19638994e8357b4ed734696f992057efaafa1235673998133299798e2ccddb
 - type: file
   dest: .m2/repository/org/apache/commons/commons-parent/65
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/65/commons-parent-65.pom
-  sha1: a5e6a3fd684242815f2ffd77ed8b316d549ed01b
+  sha256: 6cf3495fc2e6ac913a2b7f2e03fb5908fb3f229fb06d3358dc45678d5af3e36e
 - type: file
   dest: .m2/repository/org/apache/commons/commons-parent/66
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/66/commons-parent-66.pom
-  sha1: 24cf85c9d30c5ca5a2f48d806e93d8328b622a8c
+  sha256: 48fd6dc846e56b1f408660d163e75300f9e384bb63be482a8082a21d72a8db9c
 - type: file
   dest: .m2/repository/org/apache/commons/commons-parent/69
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/69/commons-parent-69.pom
-  sha1: 6ebeacd37818d945d96c06b44af10e050d2ef7c4
+  sha256: d50da9c39bdca823d618d1b4a03b73f196497fcb8616fd0da727c8623592a9bb
 - type: file
   dest: .m2/repository/org/apache/commons/commons-parent/73
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/73/commons-parent-73.pom
-  sha1: 18d2c65d184f8e59bf343ffe79676cbacf270374
+  sha256: 4ed44560b07f8448479dfd1e83a422ba4e83e60b36e51b2871ac502a6d5c1bea
 - type: file
   dest: .m2/repository/org/apache/commons/commons-parent/74
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/74/commons-parent-74.pom
-  sha1: 704abf062c1f6e03f8bcf6929b4777b9af5048a5
+  sha256: 80eb61b0c87fdd826a069313b28b672da3f1885832da447b51e6e8a6197e7ecb
 - type: file
   dest: .m2/repository/org/apache/commons/commons-parent/78
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/78/commons-parent-78.pom
-  sha1: c59670d5fff6efd8b31013cb579732c75a250b4c
+  sha256: 022d202e655edd04f2a10ecbe453d92977924d38380a4ca8c359f1817a80320e
 - type: file
   dest: .m2/repository/org/apache/commons/commons-text/1.12.0
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.12.0/commons-text-1.12.0.jar
-  sha1: 66aa90dc099701c4d3b14bd256c328f592ccf0d6
+  sha256: de023257ff166044a56bd1aa9124e843cd05dac5806cc705a9311f3556d5a15f
 - type: file
   dest: .m2/repository/org/apache/commons/commons-text/1.12.0
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.12.0/commons-text-1.12.0.pom
-  sha1: 99e12cd75786b7bf7d26b68e41783b89d346bd8c
+  sha256: b2d4341c921981cb35d5570f4fc9732a08a34b1528dee84c0507c7f2719a334f
 - type: file
   dest: .m2/repository/org/apache/groovy/groovy-bom/4.0.22
   url: https://repo.maven.apache.org/maven2/org/apache/groovy/groovy-bom/4.0.22/groovy-bom-4.0.22.pom
-  sha1: f5595adfc27fdcd4865ce6e3cb5c1f93bf50afda
+  sha256: 1e1f6b4222ae7bfd6332003edf70201835990dbd46106b16cddba8a53e3cdf65
 - type: file
   dest: .m2/repository/org/apache/httpcomponents/httpclient/4.5.14
   url: https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.jar
-  sha1: 1194890e6f56ec29177673f2f12d0b8e627dec98
+  sha256: c8bc7e1c51a6d4ce72f40d2ebbabf1c4b68bfe76e732104b04381b493478e9d6
 - type: file
   dest: .m2/repository/org/apache/httpcomponents/httpclient/4.5.14
   url: https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.pom
-  sha1: f62c6a311407cc4b47d0ea9eec6cf97ed25b8cee
+  sha256: f18355af4cf80a8a4ef04ebd742a47e90a7eaf080c725b2095dbc4fc5dbdefb7
 - type: file
   dest: .m2/repository/org/apache/httpcomponents/httpcomponents-client/4.5.14
   url: https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcomponents-client/4.5.14/httpcomponents-client-4.5.14.pom
-  sha1: e36b5c26d9012cce0ba214e06462596585475217
+  sha256: 5bad1de4f101447659f89d089868ccbad64a68cc503d2d65410b51f6904aa061
 - type: file
   dest: .m2/repository/org/apache/httpcomponents/httpcomponents-core/4.4.16
   url: https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcomponents-core/4.4.16/httpcomponents-core-4.4.16.pom
-  sha1: e0cbfde0384168cdd90e2633c1f101416d799090
+  sha256: f2d75a2c2d423ad18539bf21656d56f88a4091944a662fcaf159d5ae283db7f7
 - type: file
   dest: .m2/repository/org/apache/httpcomponents/httpcomponents-parent/11
   url: https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcomponents-parent/11/httpcomponents-parent-11.pom
-  sha1: 3ee7a841cc49326e8681089ea7ad6a3b81b88581
+  sha256: a901f87b115c55070c7ee43efff63e20e7b02d30af2443ae292bf1f4e532d3aa
 - type: file
   dest: .m2/repository/org/apache/httpcomponents/httpcore/4.4.16
   url: https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.jar
-  sha1: 51cf043c87253c9f58b539c9f7e44c8894223850
+  sha256: 6c9b3dd142a09dc468e23ad39aad6f75a0f2b85125104469f026e52a474e464f
 - type: file
   dest: .m2/repository/org/apache/httpcomponents/httpcore/4.4.16
   url: https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.pom
-  sha1: fdcd45abd94151f990a359e1d367e325cfb50286
+  sha256: 3cbad849b35dacfe6cec31adada2c623c026c3261141b0d26eec7e399c6cd7fa
 - type: file
   dest: .m2/repository/org/apache/jackrabbit/jackrabbit-parent/2.22.0
   url: https://repo.maven.apache.org/maven2/org/apache/jackrabbit/jackrabbit-parent/2.22.0/jackrabbit-parent-2.22.0.pom
-  sha1: 1df43b9490dd083e07151b913f7848c2a9fd391d
+  sha256: c834f2ed038fbc1fb7510689c8530ac2536d5cceba1dd57fe064cb7c85dd6bcd
 - type: file
   dest: .m2/repository/org/apache/jackrabbit/jackrabbit-webdav/2.22.0
   url: https://repo.maven.apache.org/maven2/org/apache/jackrabbit/jackrabbit-webdav/2.22.0/jackrabbit-webdav-2.22.0.jar
-  sha1: 6acfc3e81fc7b93ecc4d77f3efebbae617f0503b
+  sha256: 12b229a6eae94645ad7959d8015e0389af4282c3c6ee4564b69101a9feb59862
 - type: file
   dest: .m2/repository/org/apache/jackrabbit/jackrabbit-webdav/2.22.0
   url: https://repo.maven.apache.org/maven2/org/apache/jackrabbit/jackrabbit-webdav/2.22.0/jackrabbit-webdav-2.22.0.pom
-  sha1: b48b493a8fffb381ec59332cbd22d9e3bfe2be1e
+  sha256: 51286e2433d3e0a6c4f192eb80f305cc20d9074dbb7da18bc11133fd518053da
 - type: file
   dest: .m2/repository/org/apache/jena/jena/3.17.0
   url: https://repo.maven.apache.org/maven2/org/apache/jena/jena/3.17.0/jena-3.17.0.pom
-  sha1: a1d6194dd22824a316f9494b78e5b4aa92121ab3
+  sha256: cfd9198f29b614d81368001e22835f500c2264c620006b48c5951418aaf0162b
 - type: file
   dest: .m2/repository/org/apache/jena/jena-base/3.17.0
   url: https://repo.maven.apache.org/maven2/org/apache/jena/jena-base/3.17.0/jena-base-3.17.0.jar
-  sha1: 06f39e27cd2c437b611544227345bc5a5c77fb7b
+  sha256: 10e8aa3dd645f8ae369835f1b405db8e59545049426a0ee30e672ae3acc4abe5
 - type: file
   dest: .m2/repository/org/apache/jena/jena-base/3.17.0
   url: https://repo.maven.apache.org/maven2/org/apache/jena/jena-base/3.17.0/jena-base-3.17.0.pom
-  sha1: 7a52e77e6a449345d8080021bb31a8d7cff1d75d
+  sha256: f7e9afa460d91bd1aab2e430fba2ad7caca8d8f83d0e9808a5b63672d309952a
 - type: file
   dest: .m2/repository/org/apache/jena/jena-core/3.17.0
   url: https://repo.maven.apache.org/maven2/org/apache/jena/jena-core/3.17.0/jena-core-3.17.0.jar
-  sha1: 6967989413ba23fffe9254f8a534eee829486847
+  sha256: 4236eae64e89126e70d8d2dc0376923fb707157083e74b2b4b212fdeeb6e57df
 - type: file
   dest: .m2/repository/org/apache/jena/jena-core/3.17.0
   url: https://repo.maven.apache.org/maven2/org/apache/jena/jena-core/3.17.0/jena-core-3.17.0.pom
-  sha1: eb6314b0e557fa1a2f65bdc1789ed6defa3ddbf2
+  sha256: 42f0499fceab4c42796d15be575aa6768c0c05d22313f55c7f19f9da864c0036
 - type: file
   dest: .m2/repository/org/apache/jena/jena-iri/0.9.1
   url: https://repo.maven.apache.org/maven2/org/apache/jena/jena-iri/0.9.1/jena-iri-0.9.1.pom
-  sha1: 30b7a9c8ad6f6455533ff2c4e7fb5234e328b841
+  sha256: 00643f35e996cf32c8ddaa0fbaa4a0011a605cf7cde4a28a5fa97ac741fad844
 - type: file
   dest: .m2/repository/org/apache/jena/jena-iri/3.17.0
   url: https://repo.maven.apache.org/maven2/org/apache/jena/jena-iri/3.17.0/jena-iri-3.17.0.jar
-  sha1: 37798a54c45b49afa5567f8f1ca492d2d9452ef7
+  sha256: 413f4a3f3d0970853ec8fdf5a61c78fdc903c835ee225191a3cf024f376aa6cc
 - type: file
   dest: .m2/repository/org/apache/jena/jena-iri/3.17.0
   url: https://repo.maven.apache.org/maven2/org/apache/jena/jena-iri/3.17.0/jena-iri-3.17.0.pom
-  sha1: 50ff173f234583e1f9a7056e72e9b405acb750cb
+  sha256: c53bc1f7c46c2fd58f6dc6db5dacafb6c87e4a301b0ab18b0ff97304be4e6bb4
 - type: file
   dest: .m2/repository/org/apache/jena/jena-parent/1
   url: https://repo.maven.apache.org/maven2/org/apache/jena/jena-parent/1/jena-parent-1.pom
-  sha1: 05c0c844b985dd109beb7ce22a7d59f203ea67b1
+  sha256: 65a197f88e6feb4622da98a250882dd0c76c72de64c49b6b067e874f38bb7780
 - type: file
   dest: .m2/repository/org/apache/jena/jena-shaded-guava/3.17.0
   url: https://repo.maven.apache.org/maven2/org/apache/jena/jena-shaded-guava/3.17.0/jena-shaded-guava-3.17.0.jar
-  sha1: 335f3eb88dcbb453a144d9690d8fb7c5e106daa1
+  sha256: d5d94121d01547168026b4ce9ca0a8b76c7b5585a9de93b408eb2144225be233
 - type: file
   dest: .m2/repository/org/apache/jena/jena-shaded-guava/3.17.0
   url: https://repo.maven.apache.org/maven2/org/apache/jena/jena-shaded-guava/3.17.0/jena-shaded-guava-3.17.0.pom
-  sha1: 2a132b8919026d9dc8723ac4eac105db5cbbf084
+  sha256: 7c63cc7b619cc60c2b580998e0bd25dd0bdb449aa00843892d3b6baa5cc81c50
 - type: file
   dest: .m2/repository/org/apache/logging/log4j/log4j/2.23.1
   url: https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j/2.23.1/log4j-2.23.1.pom
-  sha1: a77a3c04274a5d812b964c5a020deb5a44f7f444
+  sha256: 6ce1540455364b53ea22a18342cb126a6381633f653f095467f2aa198511a6ce
 - type: file
   dest: .m2/repository/org/apache/logging/log4j/log4j/2.24.2
   url: https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j/2.24.2/log4j-2.24.2.pom
-  sha1: b7deb9632a49755d0ed1ced916c910e65961db74
+  sha256: 4d8d583368f47935463e1a671502d59019c74af4a48bbb23a223a9b48f01f479
 - type: file
   dest: .m2/repository/org/apache/logging/log4j/log4j-api/2.23.1
   url: https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-api/2.23.1/log4j-api-2.23.1.pom
-  sha1: e7956cd0359e2781cd9d197a8d46fb654d00f8bc
+  sha256: b67cc3d0980927049a3beb00d506ece288746732b0dec812245c59f453fb1ca1
 - type: file
   dest: .m2/repository/org/apache/logging/log4j/log4j-api/2.24.2
   url: https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-api/2.24.2/log4j-api-2.24.2.jar
-  sha1: daf49ee71f2664c3ff57412e4b43061e61a28596
+  sha256: 0ca3ecbd4c315bdd5f2ef6af127712df718c78334cce5bf6fb7b4aa17fdab126
 - type: file
   dest: .m2/repository/org/apache/logging/log4j/log4j-api/2.24.2
   url: https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-api/2.24.2/log4j-api-2.24.2.pom
-  sha1: 38df3205acf033add9f0ac045cd9bd96ea1861ce
+  sha256: 3efcd2614bbfc590959490f1dc5817c141919981d9e9d69a65264a1731e158a7
 - type: file
   dest: .m2/repository/org/apache/logging/log4j/log4j-bom/2.14.0
   url: https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-bom/2.14.0/log4j-bom-2.14.0.pom
-  sha1: 17fe7b392c18590d067af587a306560d8ddf2a22
+  sha256: f8e6b51d887e636da1c9aa89081b640b81f5215bfa3b083bfdec67c630a2b2e7
 - type: file
   dest: .m2/repository/org/apache/logging/log4j/log4j-bom/2.23.1
   url: https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-bom/2.23.1/log4j-bom-2.23.1.pom
-  sha1: 880a6912627a714370b8b19367bb98c73f9a763d
+  sha256: 372396e0458d4cd32c096cadabe0cc9330ec10f4f57fa3be2e74f79b5e178a35
 - type: file
   dest: .m2/repository/org/apache/logging/log4j/log4j-bom/2.24.2
   url: https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-bom/2.24.2/log4j-bom-2.24.2.pom
-  sha1: b4d73e9c326da159800710400d39badffee8020b
+  sha256: 3502889427b26f17ef4ad816802c49b4943f0c939726861d1263e57a72a23046
 - type: file
   dest: .m2/repository/org/apache/logging/log4j/log4j-to-slf4j/2.24.2
   url: https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-to-slf4j/2.24.2/log4j-to-slf4j-2.24.2.jar
-  sha1: f1c0cfff546a60d0688c709bd593a3dba629750e
+  sha256: 4960a422822cd1c8f743b7ea185aa8cee15a9ae7b54fa464046e70b9bf973449
 - type: file
   dest: .m2/repository/org/apache/logging/log4j/log4j-to-slf4j/2.24.2
   url: https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-to-slf4j/2.24.2/log4j-to-slf4j-2.24.2.pom
-  sha1: 00c3a9e59b682c670a58f0287cd50fe88831a055
+  sha256: 3fd7478a421d0ed9f59a98121c2469b888df2b1fe76bf06d8c0befd84c42087e
 - type: file
   dest: .m2/repository/org/apache/logging/logging-parent/3
   url: https://repo.maven.apache.org/maven2/org/apache/logging/logging-parent/3/logging-parent-3.pom
-  sha1: 5aacbd3590605400bd3b29892751c6d70d810a75
+  sha256: 763a2ec2b8094d4161deb6c264b1262085b9be30bf3a31c2ce137242e57722a7
 - type: file
   dest: .m2/repository/org/apache/logging/logging-parent/10.6.0
   url: https://repo.maven.apache.org/maven2/org/apache/logging/logging-parent/10.6.0/logging-parent-10.6.0.pom
-  sha1: 95a0a7ac9287a65d508ab8cc880cd90f9ef93047
+  sha256: f827475840a64083b585ec8dbbf7093b6fd02624293cec37d56edf9fc354109e
 - type: file
   dest: .m2/repository/org/apache/logging/logging-parent/11.3.0
   url: https://repo.maven.apache.org/maven2/org/apache/logging/logging-parent/11.3.0/logging-parent-11.3.0.pom
-  sha1: 01cd611f1812fbb7ae78de8bbe57c2bb4129d5f2
+  sha256: a5c985b56fe1c58433393b5091a6f39e5b9f78518dd8fc92134690599b64d7d0
 - type: file
   dest: .m2/repository/org/apache/maven/doxia/doxia/2.0.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia/2.0.0/doxia-2.0.0.pom
-  sha1: a6aca6d2d7ad6e425b345c212fde1271e5154cbe
+  sha256: 59f40c92b9f525bb6ca6f8845ec63b13dab18c3c1da93d17620cb8d2ea4c61b8
 - type: file
   dest: .m2/repository/org/apache/maven/doxia/doxia-core/2.0.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-core/2.0.0/doxia-core-2.0.0.jar
-  sha1: 6b8dd422ff321fdbf32a0196b85cce3d63cfe68c
+  sha256: 939183cf5ced6741745b2475a4adf78ca85885ee0dad6dae28dd3f25bd447ff3
 - type: file
   dest: .m2/repository/org/apache/maven/doxia/doxia-core/2.0.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-core/2.0.0/doxia-core-2.0.0.pom
-  sha1: ace68d2b112af8cf9cfe812e2d345282630172f8
+  sha256: f3e804d91571075e6367cff9020641d79d66bc46a6c13a62fcba1d369cd8936d
 - type: file
   dest: .m2/repository/org/apache/maven/doxia/doxia-integration-tools/2.0.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-integration-tools/2.0.0/doxia-integration-tools-2.0.0.jar
-  sha1: ce08d289ed826416983860fb2adced6dd7ade550
+  sha256: 4aee72f9b30b507964c2f52b63f70e7b41fb9d957359cb5dc13c428abb4b6189
 - type: file
   dest: .m2/repository/org/apache/maven/doxia/doxia-integration-tools/2.0.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-integration-tools/2.0.0/doxia-integration-tools-2.0.0.pom
-  sha1: 82d498ee1753487660d3d2428637e4f3bd0f9553
+  sha256: b3707bdb06778745b0304985c340a9847eeda20f4ca7f2902faf6c266cc29653
 - type: file
   dest: .m2/repository/org/apache/maven/doxia/doxia-module-apt/2.0.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-module-apt/2.0.0/doxia-module-apt-2.0.0.jar
-  sha1: 0505b4e8d57eb3f8c3d66adcca85ce09311742ba
+  sha256: f4a846c448ca85358279184a310f6ee3f46fa39688f74a72961c1bfe222f28a6
 - type: file
   dest: .m2/repository/org/apache/maven/doxia/doxia-module-apt/2.0.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-module-apt/2.0.0/doxia-module-apt-2.0.0.pom
-  sha1: 6fcaf23da33d7f71d6f23611b8015d208f8a371d
+  sha256: 15d5d2bcd6fe003c4d181f1b9e88b3e09611e85385246105fc5977301f2c7e96
 - type: file
   dest: .m2/repository/org/apache/maven/doxia/doxia-module-xdoc/2.0.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-module-xdoc/2.0.0/doxia-module-xdoc-2.0.0.jar
-  sha1: fe3a51c0226cb7cdfdcc97b73681f6ee80fad72c
+  sha256: 7956aca14f8adbc48bac86b218701dd44cc990063a69edbfca363b105994a474
 - type: file
   dest: .m2/repository/org/apache/maven/doxia/doxia-module-xdoc/2.0.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-module-xdoc/2.0.0/doxia-module-xdoc-2.0.0.pom
-  sha1: a1638dc3dc818b35ce9735a3c35751365c426723
+  sha256: c2e591fac5e62327c13a267c41ec21d1330e5fcbb943c56fbd6803132e7b1115
 - type: file
   dest: .m2/repository/org/apache/maven/doxia/doxia-module-xhtml5/2.0.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-module-xhtml5/2.0.0/doxia-module-xhtml5-2.0.0.jar
-  sha1: 15fbcfe42e0a50eb33adbc061c9b4db84ec0470e
+  sha256: c91557679a0eb9fde3175055628ceb7b8fd5ab6d308340770d236fb06265dc26
 - type: file
   dest: .m2/repository/org/apache/maven/doxia/doxia-module-xhtml5/2.0.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-module-xhtml5/2.0.0/doxia-module-xhtml5-2.0.0.pom
-  sha1: 56bc5f8c68b138581f2aae9912275b61fb7d34cd
+  sha256: 3c6bff4151d35b94c3afb4a0c9377c262ced4eb2dd1009970396d4c79eb73e6e
 - type: file
   dest: .m2/repository/org/apache/maven/doxia/doxia-modules/2.0.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-modules/2.0.0/doxia-modules-2.0.0.pom
-  sha1: 3b522de4bfb4d3051fd420a4963ba631cb8d2bf4
+  sha256: 9c56654ceff62d08b19b802d7d4d77dca54b17548b9802a0ba493f72f2adaf34
 - type: file
   dest: .m2/repository/org/apache/maven/doxia/doxia-sink-api/2.0.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sink-api/2.0.0/doxia-sink-api-2.0.0.jar
-  sha1: d767d78857c1fb3cbd21ae3a7870894476ecb0fc
+  sha256: fba33eaee3b01547bcd14b05ebc37f7dacef1819ad9ee7a5b27899afd3472cf4
 - type: file
   dest: .m2/repository/org/apache/maven/doxia/doxia-sink-api/2.0.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sink-api/2.0.0/doxia-sink-api-2.0.0.pom
-  sha1: a27fbb23c3649626099ab020fb246562766fff96
+  sha256: 4b05895d1cd65013d4b8e7eeb09cde6b567b4c31729fe5c77c0f0898b5e04b88
 - type: file
   dest: .m2/repository/org/apache/maven/doxia/doxia-site-model/2.0.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-site-model/2.0.0/doxia-site-model-2.0.0.jar
-  sha1: 6a43c5b58b9acbf789618efdda23d5cb9fb0981f
+  sha256: f6ec9ef75a41d1b826e5ecf02d92c5de90a6bc70ea93d5340988703223bf2205
 - type: file
   dest: .m2/repository/org/apache/maven/doxia/doxia-site-model/2.0.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-site-model/2.0.0/doxia-site-model-2.0.0.pom
-  sha1: e12a7422eebebadb7acf0936607ec4aac1643eb5
+  sha256: 25a17abcbd162cf65dfae5bd7400611d19e424d679e132e9a9228346c6d78d42
 - type: file
   dest: .m2/repository/org/apache/maven/doxia/doxia-site-renderer/2.0.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-site-renderer/2.0.0/doxia-site-renderer-2.0.0.jar
-  sha1: b68214ec1d3250a4594f598f054977d961e66ac8
+  sha256: 6cdee370194f4b9f742d12ef46528042f480d9bdf3de832de2792e1ae9ffc68d
 - type: file
   dest: .m2/repository/org/apache/maven/doxia/doxia-site-renderer/2.0.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-site-renderer/2.0.0/doxia-site-renderer-2.0.0.pom
-  sha1: db7977cd6794d046a7c92a2cfee5517e612e82f5
+  sha256: 3add9e92edb232902aaf8f663b48d9f8dbec1792436f4f9c36f3665b86266d8d
 - type: file
   dest: .m2/repository/org/apache/maven/doxia/doxia-sitetools/2.0.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sitetools/2.0.0/doxia-sitetools-2.0.0.pom
-  sha1: 29ab46ca2e9ab1d6188df99fec92c53c29726dd0
+  sha256: ad3dcd30a40d45148350f066f2312ed9f946b7fd94f9c197ede0f3b9558b80a3
 - type: file
   dest: .m2/repository/org/apache/maven/doxia/doxia-skin-model/2.0.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-skin-model/2.0.0/doxia-skin-model-2.0.0.jar
-  sha1: 86913a4d7f1acbf26d426c97adecb18e21938ebf
+  sha256: 3ced0d90353f49e8eb1458f54664b93ec117d79b9789a576da41e2f6f99723e0
 - type: file
   dest: .m2/repository/org/apache/maven/doxia/doxia-skin-model/2.0.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-skin-model/2.0.0/doxia-skin-model-2.0.0.pom
-  sha1: 9c971107752c64dcf6563606e7b4ca54d21da166
+  sha256: 10bbc5674fab0fa2bbcf8f7696796d3e1b92ab31525330921fbdb8da74fe1472
 - type: file
   dest: .m2/repository/org/apache/maven/maven/3.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven/3.0/maven-3.0.pom
-  sha1: 30c961aaf964aadcc028102ebe03d1afff324ec0
+  sha256: 28fc63720c4a5ff92bf0e358ed55a6f24626f35bccc13cc3e194231e158848f6
 - type: file
   dest: .m2/repository/org/apache/maven/maven-archiver/3.6.2
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/3.6.2/maven-archiver-3.6.2.jar
-  sha1: a2d949d87fed6db197cc3cceec93012dd2317ca0
+  sha256: 1f895a587df4844d9b7565e8e9a6352afe1d55532458a0dbeb746bc1d02e9216
 - type: file
   dest: .m2/repository/org/apache/maven/maven-archiver/3.6.2
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/3.6.2/maven-archiver-3.6.2.pom
-  sha1: 1eaa320b6d9c675e83099baf7a0ecf5ca232f9ba
+  sha256: 8b117b0dc205a71abda33463f8c7ff891513cfb92241d8a011f9e8ac5ea21e77
 - type: file
   dest: .m2/repository/org/apache/maven/maven-archiver/3.6.3
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/3.6.3/maven-archiver-3.6.3.jar
-  sha1: 21bb08817d17bcca18207e3af6af46ecf8d21909
+  sha256: 83566129898c7a384bffaa118a76a40667d546948460b43eeb8563fa17635848
 - type: file
   dest: .m2/repository/org/apache/maven/maven-archiver/3.6.3
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/3.6.3/maven-archiver-3.6.3.pom
-  sha1: da64a541cf027e1a4bd0b74730a019c5829048b6
+  sha256: bc130259c5e1087a270ea8cf3f8182fecc90bf93113a2074d640a1a67f102ec4
 - type: file
   dest: .m2/repository/org/apache/maven/maven-model/3.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.0/maven-model-3.0.pom
-  sha1: 3aa89da7792286192b860c58841b3907364d33a8
+  sha256: 3d6fdeb72b2967f1fa2784134fb832d08d8d6e879b7ace7712f2c7281994fc1e
 - type: file
   dest: .m2/repository/org/apache/maven/maven-parent/15
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/15/maven-parent-15.pom
-  sha1: 63d5a76e7f9d3c6d7870bde13438856ef5300336
+  sha256: e25770d5d46dcdfdbb9e38ca04f272c5bdf476d88392ab4044ba90678e616d54
 - type: file
   dest: .m2/repository/org/apache/maven/maven-parent/23
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/23/maven-parent-23.pom
-  sha1: f92ae4baba6616609a29f6287626ee3f50ed7d6e
+  sha256: 5425501edd9e0bd7b01eca53cc92e06836d24851151304f9c6759e1713541685
 - type: file
   dest: .m2/repository/org/apache/maven/maven-parent/30
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/30/maven-parent-30.pom
-  sha1: c3b2d24677a5f694e069b8210e9793a88c9d28b5
+  sha256: 70709ad646f5aa57bb44e2a8b4f3de4993b108202ba095bd164e41cdc3181e70
 - type: file
   dest: .m2/repository/org/apache/maven/maven-parent/33
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/33/maven-parent-33.pom
-  sha1: 9dd736089b07fa56da1259c87a825a097ba0278c
+  sha256: 3856e3fcd169502d5f12fe2452604ebf6c7c025f15656bfa558ea99ed29d73ea
 - type: file
   dest: .m2/repository/org/apache/maven/maven-parent/34
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/34/maven-parent-34.pom
-  sha1: d03d96b2f4ee06300faa9731b0fa71feeec5a8ef
+  sha256: 1a8faf7a6a2b848acb26a959954ee115c0d79dbe75a6206fb3b8c7c2f45a237f
 - type: file
   dest: .m2/repository/org/apache/maven/maven-parent/35
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/35/maven-parent-35.pom
-  sha1: 2f65ed06ef7e7380517578cbc7a2b2f6b7cc4989
+  sha256: d2edd4077c0abc9cc8202883c459503180424636cb39a83031ec1112394b2576
 - type: file
   dest: .m2/repository/org/apache/maven/maven-parent/36
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/36/maven-parent-36.pom
-  sha1: af78602525e1c7ac4575ef2e3059b7910bb79f3a
+  sha256: fcc3ab64c3cc80966d562a9aa604d8c280b3b7092441dd09e5290b081dfbedb5
 - type: file
   dest: .m2/repository/org/apache/maven/maven-parent/39
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/39/maven-parent-39.pom
-  sha1: 9b763d93ee3622181d8d39f62e8e995266c12362
+  sha256: cfe4820aa1d96ae51d1dc5b0e2a9dc582c42478c24c95ca8238f547e60bef721
 - type: file
   dest: .m2/repository/org/apache/maven/maven-parent/41
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/41/maven-parent-41.pom
-  sha1: c60098252d5841553d75a7d7382db46e6859d84d
+  sha256: 762fcdd4ce8621c5fa0a2cf6495ad26972a8093eb432aa3e402bc2d4e2500c53
 - type: file
   dest: .m2/repository/org/apache/maven/maven-parent/42
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/42/maven-parent-42.pom
-  sha1: c47c2942c1347b1f221c113c96056a8ba44a2f49
+  sha256: 04534dea350a2187970a5b74444338bcf78ba8e537d44f262acfba16ebb33056
 - type: file
   dest: .m2/repository/org/apache/maven/maven-parent/43
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/43/maven-parent-43.pom
-  sha1: b9346196901d4f22b4f92a3c3f0d21d436308b03
+  sha256: 468a1262e9aaa5febf9d604e2836267f815351f2b4520f28fb17f53c71e33554
 - type: file
   dest: .m2/repository/org/apache/maven/maven-parent/44
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/44/maven-parent-44.pom
-  sha1: e7857131e733520e8e020e02f0d90f269cc37342
+  sha256: 1c0a088d7352d52ea8f3581d05778c0c4a679613fff2c58737fba55f1007fe24
 - type: file
   dest: .m2/repository/org/apache/maven/maven-plugin-api/3.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.0/maven-plugin-api-3.0.pom
-  sha1: 9627e130b4f516945f0db03119dbafb86f168026
+  sha256: 8a722af2564205ae996f9035cc04670d3e9e4ae592f5a643c58fb7b0f43e1501
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-clean-plugin/3.2.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-clean-plugin/3.2.0/maven-clean-plugin-3.2.0.jar
-  sha1: 556f5c71be8788c70a94a43d66af7fe35acee21f
+  sha256: b657bef2e1eb11e029a70cd688bde6adad29e4e99dacb18516bf651ecca32435
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-clean-plugin/3.2.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-clean-plugin/3.2.0/maven-clean-plugin-3.2.0.pom
-  sha1: f6f7ce25e8d638408c20f1888b2664f49df9f5a1
+  sha256: 5b25a527e8b437d0e1bc0e589b435652c59a63eb3600f8333032abda6b11b376
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-compiler-plugin/3.14.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.14.0/maven-compiler-plugin-3.14.0.jar
-  sha1: 8da644b4b26eb34e626ad9482a884a89e6657901
+  sha256: e55fe35b95cf499e5092f146c6613984cff896a8947c2f347ab88270f11acb76
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-compiler-plugin/3.14.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.14.0/maven-compiler-plugin-3.14.0.pom
-  sha1: 2462cca3877549cf4c116cf5e5b6b06a87695ab1
+  sha256: 9a380f4d0edbcb96ad495c6bdf116ee0ac74964d24bbce2590280e9b326ae897
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-dependency-plugin/3.8.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-dependency-plugin/3.8.1/maven-dependency-plugin-3.8.1.jar
-  sha1: 4948ae04c9ee25b7ca00cf71de2762d1f30bc029
+  sha256: 9fc3d435085983b16bc53903f9413aede9de30e20c57c0cece94614f328b14b5
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-dependency-plugin/3.8.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-dependency-plugin/3.8.1/maven-dependency-plugin-3.8.1.pom
-  sha1: 0836cfc67a6e7d3133288f5f527ea6950e76ddf0
+  sha256: 4ad37e717dc713cec048b143f0de8fdd37d037f7d15be63f130cf96430caa808
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-jar-plugin/3.4.2
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/3.4.2/maven-jar-plugin-3.4.2.jar
-  sha1: 0a0a87aac2d20eb362d902d560294294fb26eacb
+  sha256: e02b19fb8e7ea10baed4878a8c51e4ea21f16ef927efcfb2681a8faea86c7abb
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-jar-plugin/3.4.2
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/3.4.2/maven-jar-plugin-3.4.2.pom
-  sha1: 388d7cde37747422363dced3f5326238a7a578af
+  sha256: 1b6e93c9c1d87b893808d9efc07f56638e60909d501558b11838659b937157af
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-plugins/35
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/35/maven-plugins-35.pom
-  sha1: 819905e407cb91f2dbddc84b85b992f67a711b6d
+  sha256: 42d759c550d723373ae34556e80930b9ed2e13495dace134adf99e64ddc8d2e1
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-plugins/39
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/39/maven-plugins-39.pom
-  sha1: 0cc43509e437079ac1255236ccdcbef302daa93d
+  sha256: 18085afbef3a17942b442135a3f0e77018cda66edd33c6b18fd18440661bc29e
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-plugins/42
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/42/maven-plugins-42.pom
-  sha1: 29c252d69753502d9e9435d05c1814c79e88f16e
+  sha256: 5b31681ea67e838a8ed1f08af891d1ae50f16dfadd3fc2b787900ed69d5f2503
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-plugins/43
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/43/maven-plugins-43.pom
-  sha1: f030fc4091a996ce3990bd7da5bcc9cb4561ca46
+  sha256: a177f84e01c3829a357b8f135686ae7dd8c35d1c2089a390ef089340aa47cd21
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-resources-plugin/3.3.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/3.3.1/maven-resources-plugin-3.3.1.jar
-  sha1: 5a0e59faaaec9485868660696dd0808f483917d0
+  sha256: eb4069c7fe50a313b3f5295ccd214f30402f63971c26f443f7f3e798be8cc2a7
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-resources-plugin/3.3.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/3.3.1/maven-resources-plugin-3.3.1.pom
-  sha1: 9966f75b0f17184e0a3b7716adcb2f6b753e3088
+  sha256: 3269d0a6e3cd614a29486f57fc86488b0f1e458a11bebc61f9408fd6c7cf85ae
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-surefire-plugin/3.5.3
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/3.5.3/maven-surefire-plugin-3.5.3.jar
-  sha1: e8a340079d94a7375a7c366c9cf1ab445fc309a6
+  sha256: 5b5b35523b04916eee85ad6d898b0353dd2ac00793b90d9e7befb79197873d9d
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-surefire-plugin/3.5.3
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/3.5.3/maven-surefire-plugin-3.5.3.pom
-  sha1: 83a51c0fb63bb2b03f0d1897ae3313f758cf36a7
+  sha256: eb52f2f868ac123d408ceefe32dc8d1647383d8035245374dd16cf93479b6c59
 - type: file
   dest: .m2/repository/org/apache/maven/reporting/maven-reporting-api/4.0.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/4.0.0/maven-reporting-api-4.0.0.jar
-  sha1: d3ad7e3d03463b5bd77e7d3ce94539cc723c8dfb
+  sha256: cb2cbde3c9c7288f7398a250dcf3c90cf92714cff301f22b298e1091b5def33c
 - type: file
   dest: .m2/repository/org/apache/maven/reporting/maven-reporting-api/4.0.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/4.0.0/maven-reporting-api-4.0.0.pom
-  sha1: bf5464de56df02a76ce5b2068e81648452369d51
+  sha256: 2032531f05994121c2fdb5df7235ed548f53d294d0b7ac45e797148d85a30ee2
 - type: file
   dest: .m2/repository/org/apache/maven/reporting/maven-reporting-impl/4.0.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-impl/4.0.0/maven-reporting-impl-4.0.0.jar
-  sha1: d3753b5c13a873a5ddb71f404c6fe1179a4688c2
+  sha256: e9e70fdb26ff8b1f15435e3a68866a25c85b1694007e0fbdfe84e48e946fe463
 - type: file
   dest: .m2/repository/org/apache/maven/reporting/maven-reporting-impl/4.0.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-impl/4.0.0/maven-reporting-impl-4.0.0.pom
-  sha1: 7adaa6b06545c212bd8491586ebed70e9a65fbf9
+  sha256: e049cf5b77d09c24e83db9fd8f5019bdf86dc37a3357f5634c56fb157ecda248
 - type: file
   dest: .m2/repository/org/apache/maven/resolver/maven-resolver/1.4.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver/1.4.1/maven-resolver-1.4.1.pom
-  sha1: 7cffb7488c6b0c702113af053da975fdbd92df3d
+  sha256: 831c3849751101226495acfe9119582feb734a4539b070e0fbd9e85b03b501ce
 - type: file
   dest: .m2/repository/org/apache/maven/resolver/maven-resolver-api/1.4.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-api/1.4.1/maven-resolver-api-1.4.1.jar
-  sha1: ceee6b7ea1bc252afa585fa32f76c2cda206bdcd
+  sha256: 33dc67306cc95da14e5444e8b494d967924abf1d01bae1894676164cbd3f6112
 - type: file
   dest: .m2/repository/org/apache/maven/resolver/maven-resolver-api/1.4.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-api/1.4.1/maven-resolver-api-1.4.1.pom
-  sha1: 4eda1737c26ab3517013e30d9254c868c7097013
+  sha256: 335513ce1dd2cf4c7d1dbfa1b8aa14656d9be5f9f3f0d0875ac528893c9f0f06
 - type: file
   dest: .m2/repository/org/apache/maven/resolver/maven-resolver-util/1.4.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-util/1.4.1/maven-resolver-util-1.4.1.jar
-  sha1: 3f6d4f4bc3e24b46a776b47ccfeaed9d2ed01549
+  sha256: 6b2184872fa7cc2ef5a90481b56af9711c15b371e69ab52f0f31bf24e910dd82
 - type: file
   dest: .m2/repository/org/apache/maven/resolver/maven-resolver-util/1.4.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-util/1.4.1/maven-resolver-util-1.4.1.pom
-  sha1: bf9f92c4886f8281a215b486fc0ccc2242b809b8
+  sha256: a58c932e967e85e7bcb8d4adaedd14a5221a1750a1d089c5086c4d73df505155
 - type: file
   dest: .m2/repository/org/apache/maven/shared/file-management/3.1.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/file-management/3.1.0/file-management-3.1.0.jar
-  sha1: f87a3a54c856714e4157b9ce7a5ff6ffc310d447
+  sha256: 2e8cb2d546a01c2259cb17f1e06732db3d14b079d19622bf8400c82cb1ee6b96
 - type: file
   dest: .m2/repository/org/apache/maven/shared/file-management/3.1.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/file-management/3.1.0/file-management-3.1.0.pom
-  sha1: 8c2dcedec327bbb9daf24ced48fc59ce228a6b1f
+  sha256: 5e93a63b3042023e558dcbeb19914ce82e6a6fbccdbd68797f80b135121a8bde
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-artifact-transfer/0.13.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.13.1/maven-artifact-transfer-0.13.1.jar
-  sha1: 9f6d2088ae64dd926b8ec445afdb7e148eb08060
+  sha256: 1ac88accde99ed71e65253bd130868c0e654f940f01ade073b895eb2f817cf06
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-artifact-transfer/0.13.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.13.1/maven-artifact-transfer-0.13.1.pom
-  sha1: c069577d8112a71485cbb6e52a26d87e85e3489a
+  sha256: e4b15a1e7cfbfe480408cfbaa148d66ea3324bf19e9ac6d6c17053bdb18ac4cd
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-common-artifact-filters/3.1.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.1.0/maven-common-artifact-filters-3.1.0.pom
-  sha1: 2b2b1b986c2c758db97d6e6c399aab368e323f98
+  sha256: 034e12a9d1d5f5618a9e0dda23aadda4ed659ec55240876b6e954cc2172be456
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-common-artifact-filters/3.4.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.4.0/maven-common-artifact-filters-3.4.0.jar
-  sha1: 25855b1fa26fa5a1b387375de4b14ac39df23981
+  sha256: 931a77aa9dad6c91f10fcfafa70adc7608c004576b4924c74ecbffb27568a880
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-common-artifact-filters/3.4.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.4.0/maven-common-artifact-filters-3.4.0.pom
-  sha1: 3999b773fe3f35c42b07e8f855a59b372b828acf
+  sha256: c93581d69b337c1fcc0957c727c430180b6387276ef1d3c2976c175e93765eb1
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-dependency-analyzer/1.15.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-dependency-analyzer/1.15.0/maven-dependency-analyzer-1.15.0.jar
-  sha1: 2a0d474df4f877f72869c72adda0d6a9a6750827
+  sha256: b12afa13e722e991c28a45b53277be406e6433591c863eb7d0b9d350803c3a69
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-dependency-analyzer/1.15.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-dependency-analyzer/1.15.0/maven-dependency-analyzer-1.15.0.pom
-  sha1: 2db43d59e48c311fd748bf52bdc5ffbcde02388d
+  sha256: e4f76e39dc078816bb8de311015374122d24b4418122cde0df263ad4e8656bf9
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-dependency-tree/3.3.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-dependency-tree/3.3.0/maven-dependency-tree-3.3.0.jar
-  sha1: d9bca2c7d845fbc10b3a94082c489a33b520dfc9
+  sha256: a3353f6a82feb950d5e7e64b0cd4ceadea7eb62112e447172e34974a510316f4
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-dependency-tree/3.3.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-dependency-tree/3.3.0/maven-dependency-tree-3.3.0.pom
-  sha1: 12498f446dbccb51e5cfa7905331d0537eea9d07
+  sha256: 06d3cdd58a0bcec206558ade256147aade63a166b042ef53215df6c51206d920
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-filtering/3.3.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-filtering/3.3.1/maven-filtering-3.3.1.jar
-  sha1: 7b613072bcce1d949b6d82f714af08b4535aae2b
+  sha256: b12663187d9ffc6a1ee76139c0ef497fe9400efbe2ebe01616fe2703656fb4f0
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-filtering/3.3.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-filtering/3.3.1/maven-filtering-3.3.1.pom
-  sha1: 892af5bd3778032e12cb527cab28ee8651fbee4f
+  sha256: a1d90278a9c3effef6c45db86c660749d2910d8d7361ed81983565950f667e85
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-components/19
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/19/maven-shared-components-19.pom
-  sha1: 650a49682d4c82f060c7cc8005f8734a5fd86af9
+  sha256: d82408269aada2eb1521ee8ff17f7c67333684f8ed2a09a9e35badd2e7575957
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-components/30
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/30/maven-shared-components-30.pom
-  sha1: fed1e8496612f1fd3621e686a4cee4ea56d04cf9
+  sha256: ad9df3b73df8bbc0309ad42818fa9779cd10528df0708788f4aceddc514bd031
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-components/33
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/33/maven-shared-components-33.pom
-  sha1: 3eb04765b707822b0b97eae2648b1054e21cbdb3
+  sha256: f43ff6fee0b32533765b3406648d6a5532f85d5e488079480788cb36e79d0980
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-components/34
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/34/maven-shared-components-34.pom
-  sha1: 633600d0ac8d18b70b559a90fa62ad4e90e8dc15
+  sha256: 64d0edb5f21cfff600b1c3ab7d45f9754cd18ba5fbf83b3d1bb7c4849437d8e3
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-components/36
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/36/maven-shared-components-36.pom
-  sha1: 0376c5365dff8496ca0185247296d760ee80dfec
+  sha256: ec8e973e7964aaf490dbddd39f312340e00d113b8470f135a13e35e45f4baf9f
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-components/39
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/39/maven-shared-components-39.pom
-  sha1: c6707d46530a62cdc0e6d9cf70061f80d002f862
+  sha256: 17e81388d88ba61c4055450ec90a32ee30acd07f46dc6e31e096b8e53735f4b2
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-components/41
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/41/maven-shared-components-41.pom
-  sha1: f065cc41ea386a672156b8df42c4409ef1a972b2
+  sha256: c6bd81e2588e0f0f87392d4db590e1d81c126a25ee9253252ef89c506cde1e34
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-components/42
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/42/maven-shared-components-42.pom
-  sha1: e20e297468e4a64b1fef019112bdbe19767a975f
+  sha256: aa66faa11c11b900d099bfef0ee9fe8485d7e7fc74e87193e1f74572ed9587c5
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-components/43
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/43/maven-shared-components-43.pom
-  sha1: fc6ef17410db522fc61d43e3d23e7a47a738b0db
+  sha256: 6072dd103bdba3199584c5b73ed45b00567cd3ea918e2160b10bc7437c9e8181
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-incremental/1.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.jar
-  sha1: 9d017a7584086755445c0a260dd9a1e9eae161a5
+  sha256: 61988e54486a5dc38f06c70fdae5b108556c63bd433697b9f4305fcdb30fa40e
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-incremental/1.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.pom
-  sha1: c607b2c64c027151c440f27b5ec86e062b9e9953
+  sha256: f21d19eb49b4a66cd85354a9ee7335439ea92a368173760a202766008cc19924
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-utils/3.1.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.1.0/maven-shared-utils-3.1.0.pom
-  sha1: 96d533d4ae5c8ae5abe3f2e04fea554e2b03fd99
+  sha256: 68f9fdef85d2c89f53c63cbc559920e0115bd30eb6f7076c9854931d3829027b
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-utils/3.3.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.3.4/maven-shared-utils-3.3.4.jar
-  sha1: f87a61adb1e12a00dcc6cc6005a51e693aa7c4ac
+  sha256: 7925d9c5a0e2040d24b8fae3f612eb399cbffe5838b33ba368777dc7bddf6dda
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-utils/3.3.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.3.4/maven-shared-utils-3.3.4.pom
-  sha1: 9e3c134dc5c3f2a588203ce1cd137b7c3c51c642
+  sha256: bf83482d96f76d63699d63e125e64f4ac73c8178985733662dbd69af9c60339e
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-utils/3.4.2
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.4.2/maven-shared-utils-3.4.2.jar
-  sha1: bfa28296272a5915b08de9f11f34a94b0a818fd0
+  sha256: b613357e1bad4dfc1dead801691c9460f9585fe7c6b466bc25186212d7d18487
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-utils/3.4.2
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.4.2/maven-shared-utils-3.4.2.pom
-  sha1: 78e0d256abbc6df63b2bb96493dd99daa29be63f
+  sha256: a941745d7faeb8dc9a75edc2c330c994b7440b9a44d21142716b6053967a41c1
 - type: file
   dest: .m2/repository/org/apache/maven/surefire/maven-surefire-common/3.5.3
   url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/3.5.3/maven-surefire-common-3.5.3.jar
-  sha1: ad5d607e98053054a1494503d9020a8789a4dfb9
+  sha256: 006e555577df16eaace4793ef26f7ee4058e8e2601496e38f371e288c7f32e4d
 - type: file
   dest: .m2/repository/org/apache/maven/surefire/maven-surefire-common/3.5.3
   url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/3.5.3/maven-surefire-common-3.5.3.pom
-  sha1: 0cf977e7c55a3c34e2df5e84ccb945320ee87b86
+  sha256: 10e7cb845ccb9cfef0e3505732ffdf4376869120492c4ab29d0b060944c1e5e4
 - type: file
   dest: .m2/repository/org/apache/maven/surefire/surefire/3.5.3
   url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire/3.5.3/surefire-3.5.3.pom
-  sha1: 95e714f96c69c4f233bfa3765cb5522394cd4e9f
+  sha256: 5cbfe437ff378161f3a756d36d48bde76d32cd391015a84050dc5e94e35ff3ac
 - type: file
   dest: .m2/repository/org/apache/maven/surefire/surefire-api/3.5.3
   url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/3.5.3/surefire-api-3.5.3.jar
-  sha1: 62f9634651a6d844e12db88121e4dfc1dd6b2ef7
+  sha256: a1a6a62d8998e2ad55bddfd5f27590a32e4fd46917f822ff7cfd788cffdac560
 - type: file
   dest: .m2/repository/org/apache/maven/surefire/surefire-api/3.5.3
   url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/3.5.3/surefire-api-3.5.3.pom
-  sha1: 30b167d6ac2034903b9b1922c44564dac7596fd6
+  sha256: e662beaff4d5fcf694d36e765ae351fce57ada25285b0e2fc07d1fc0166e3270
 - type: file
   dest: .m2/repository/org/apache/maven/surefire/surefire-booter/3.5.3
   url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/3.5.3/surefire-booter-3.5.3.jar
-  sha1: ddb4e6e0770b0f51a527010db40823d8cfc3b754
+  sha256: 1df1d3fb0732059384068e9a0eeef8ff378e0aedfa1e41f05aafa6539405538e
 - type: file
   dest: .m2/repository/org/apache/maven/surefire/surefire-booter/3.5.3
   url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/3.5.3/surefire-booter-3.5.3.pom
-  sha1: 0443b2332dec49f48f3356a49c9d7533cc6dc435
+  sha256: 8b47537cc1231a62c9d84350f4cf9d687e4941c27558c4d00348847373cdb656
 - type: file
   dest: .m2/repository/org/apache/maven/surefire/surefire-extensions-api/3.5.3
   url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-api/3.5.3/surefire-extensions-api-3.5.3.jar
-  sha1: 5b4dd76c8a83de00b12623fdfd6144ec0f2eb391
+  sha256: fe9a5a27e46eff07a3fce8a176d465b567cf62d59a1f0182b95996ad025adc76
 - type: file
   dest: .m2/repository/org/apache/maven/surefire/surefire-extensions-api/3.5.3
   url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-api/3.5.3/surefire-extensions-api-3.5.3.pom
-  sha1: 60481ebd58fcbc0c37ae71d2e23c5026c3f2bc4f
+  sha256: 5b0632720bb82a11e4799578caf8ec472fc0cde98cd3f3faa6ab4ce299aba469
 - type: file
   dest: .m2/repository/org/apache/maven/surefire/surefire-extensions-spi/3.5.3
   url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-spi/3.5.3/surefire-extensions-spi-3.5.3.jar
-  sha1: 500f6f7f4dadc15bbe2c14747a6384b8c03c8c01
+  sha256: dba5125d6489dad3df7d29508b3ce5c4fcc1ad772f9eb5113eeefe3bc07d5002
 - type: file
   dest: .m2/repository/org/apache/maven/surefire/surefire-extensions-spi/3.5.3
   url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-spi/3.5.3/surefire-extensions-spi-3.5.3.pom
-  sha1: 75620fc51261659616444a9f155a5b2cb03ab6db
+  sha256: 714bcec1dbc1a5117598734d7d18008a643819c052cf0df687839279e4f44b25
 - type: file
   dest: .m2/repository/org/apache/maven/surefire/surefire-logger-api/3.5.3
   url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-logger-api/3.5.3/surefire-logger-api-3.5.3.jar
-  sha1: 7735a880761ef1aa7ace8f570989c8858b4123c9
+  sha256: 81ecda3ea9f92e022599927d6b2e556f4fb8e6120adcbdf3a44102b03dee7e5c
 - type: file
   dest: .m2/repository/org/apache/maven/surefire/surefire-logger-api/3.5.3
   url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-logger-api/3.5.3/surefire-logger-api-3.5.3.pom
-  sha1: 941c71913e17a8e3497e03c9803a0fbb95e232db
+  sha256: c15836d5013d255c5a79c68de0b27d0a72adb0697dbaaf91b7247dcf17e6c21a
 - type: file
   dest: .m2/repository/org/apache/maven/surefire/surefire-shared-utils/3.5.3
   url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-shared-utils/3.5.3/surefire-shared-utils-3.5.3.jar
-  sha1: c3f98bb781d3d484700a86d12d820e746ef62360
+  sha256: 9330203cfcea65edbfaab06d62ea691eb19ff7b5012a6ebeb1968c65e3ce0465
 - type: file
   dest: .m2/repository/org/apache/maven/surefire/surefire-shared-utils/3.5.3
   url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-shared-utils/3.5.3/surefire-shared-utils-3.5.3.pom
-  sha1: d286f1466dfe5ab673c16ff944d2cc65cbf70288
+  sha256: dc985ceec4e0c41dc9ad06525539256f9c16f4dec443c7cb3fac2397357c2c83
 - type: file
   dest: .m2/repository/org/apache/poi/poi/5.3.0
   url: https://repo.maven.apache.org/maven2/org/apache/poi/poi/5.3.0/poi-5.3.0.jar
-  sha1: 0a26d24e85a2440d7b76d2ddd187abb0ee7c056e
+  sha256: d514ebff22327762d38f551b6d1d78bb764770afd8d37546387ca41790323fef
 - type: file
   dest: .m2/repository/org/apache/poi/poi/5.3.0
   url: https://repo.maven.apache.org/maven2/org/apache/poi/poi/5.3.0/poi-5.3.0.pom
-  sha1: 80d9e3f148f6780f91a30e815df08dca99954083
+  sha256: 872fe5103736e4f2cce9b5e6f5d9eb64809ed4a691b0262153719b3e1b398d3d
 - type: file
   dest: .m2/repository/org/apache/poi/poi-ooxml/5.3.0
   url: https://repo.maven.apache.org/maven2/org/apache/poi/poi-ooxml/5.3.0/poi-ooxml-5.3.0.jar
-  sha1: 55e5ecb93bd06ff70857d514b3607ae22866806c
+  sha256: 9aff00ff55aea842c67d7b042b81a0aa99e9f5e1395d9947ca7cf1bcb74e5cb1
 - type: file
   dest: .m2/repository/org/apache/poi/poi-ooxml/5.3.0
   url: https://repo.maven.apache.org/maven2/org/apache/poi/poi-ooxml/5.3.0/poi-ooxml-5.3.0.pom
-  sha1: fa7bed4cc02e20f52ec7a7c599aac66d5bb300a9
+  sha256: cf804a83ab2a0485fe2c5fdc72902168849bb5ffb88f996eef36690e500623a0
 - type: file
   dest: .m2/repository/org/apache/poi/poi-ooxml-lite/5.3.0
   url: https://repo.maven.apache.org/maven2/org/apache/poi/poi-ooxml-lite/5.3.0/poi-ooxml-lite-5.3.0.jar
-  sha1: 4a639ca45af85065713bde6c5acddbf1418c3f02
+  sha256: 78e3eee7982aba1b323caa4dcd9d9e73b6c664ab57e3104f1b61935c3321c925
 - type: file
   dest: .m2/repository/org/apache/poi/poi-ooxml-lite/5.3.0
   url: https://repo.maven.apache.org/maven2/org/apache/poi/poi-ooxml-lite/5.3.0/poi-ooxml-lite-5.3.0.pom
-  sha1: 3e5818236002280a785cc48c8fcf5559b3437d8e
+  sha256: 55e104bbf739c6f7237851d945c66c116e295e22d642b897f9f6ae5960288589
 - type: file
   dest: .m2/repository/org/apache/velocity/tools/velocity-tools-generic/3.1
   url: https://repo.maven.apache.org/maven2/org/apache/velocity/tools/velocity-tools-generic/3.1/velocity-tools-generic-3.1.jar
-  sha1: 07aaa49086a64cd9dab967a8437cc03abbfad655
+  sha256: 8258cfdcaa16127f35ffe610a3fa4f76b7ebe51b88922c73c4ee39ce8f378ce5
 - type: file
   dest: .m2/repository/org/apache/velocity/tools/velocity-tools-generic/3.1
   url: https://repo.maven.apache.org/maven2/org/apache/velocity/tools/velocity-tools-generic/3.1/velocity-tools-generic-3.1.pom
-  sha1: 1d93d47219ebd1f8ed88e3474067d92d51a02520
+  sha256: a6f50cb3f413875c039652269d2a89f8878d0d9fc8cc662fc13591ca20d84758
 - type: file
   dest: .m2/repository/org/apache/velocity/tools/velocity-tools-parent/3.1
   url: https://repo.maven.apache.org/maven2/org/apache/velocity/tools/velocity-tools-parent/3.1/velocity-tools-parent-3.1.pom
-  sha1: 4b956b827a3d86f9a85196b16818a154e8b50d4f
+  sha256: 5a597b88dba795090e77015bcdf53461b41d45da2d7d1764e4ece8b30a226fcd
 - type: file
   dest: .m2/repository/org/apache/velocity/velocity-engine-core/2.3
   url: https://repo.maven.apache.org/maven2/org/apache/velocity/velocity-engine-core/2.3/velocity-engine-core-2.3.pom
-  sha1: 108b42b3bd541f982b696293015ae192a3acb2a1
+  sha256: d4242a6174243f1e680434571ba4e6a1dbae199c0bc350a987d5fb9c3ce1e0d3
 - type: file
   dest: .m2/repository/org/apache/velocity/velocity-engine-core/2.4
   url: https://repo.maven.apache.org/maven2/org/apache/velocity/velocity-engine-core/2.4/velocity-engine-core-2.4.jar
-  sha1: 55dfc20bbc4968cf70c5ae5165b5b0324e0067d9
+  sha256: 1bf78c2ade46f209bf93ebe72ed2af5b989ca7a1de0a015fc1b92a62f56b6549
 - type: file
   dest: .m2/repository/org/apache/velocity/velocity-engine-core/2.4
   url: https://repo.maven.apache.org/maven2/org/apache/velocity/velocity-engine-core/2.4/velocity-engine-core-2.4.pom
-  sha1: 3f5e3f9b2bde829b65be0355e0b18ab95b0128f5
+  sha256: a9eee9d59ac787f9c379ec4f37af7e04f8d62161a1e602a4274014d0dc41b0cb
 - type: file
   dest: .m2/repository/org/apache/velocity/velocity-engine-parent/2.3
   url: https://repo.maven.apache.org/maven2/org/apache/velocity/velocity-engine-parent/2.3/velocity-engine-parent-2.3.pom
-  sha1: a19e108639e1a877dfd8cd204756957638b817a7
+  sha256: 4c0e4a92f6870f399b946d5bb789d177e4a47941147c3fddc2e6f063e9cb96db
 - type: file
   dest: .m2/repository/org/apache/velocity/velocity-engine-parent/2.4
   url: https://repo.maven.apache.org/maven2/org/apache/velocity/velocity-engine-parent/2.4/velocity-engine-parent-2.4.pom
-  sha1: c34d7426913e54981a254eb8b75fd19cac171501
+  sha256: d4b9e31a7e9ea490c562a2bdeced94eef3f08c8d0a5378add3d6bcf8828334bf
 - type: file
   dest: .m2/repository/org/apache/velocity/velocity-master/4
   url: https://repo.maven.apache.org/maven2/org/apache/velocity/velocity-master/4/velocity-master-4.pom
-  sha1: d1cafcce1773b4e8762a527bf0a9afb52b1b687b
+  sha256: 7a2ac73c90dd104b5a07e6e2cd03e95ec28d29f3b8304f3dd7fffcecb049712e
 - type: file
   dest: .m2/repository/org/apache/velocity/velocity-master/7
   url: https://repo.maven.apache.org/maven2/org/apache/velocity/velocity-master/7/velocity-master-7.pom
-  sha1: 825154269cc620056fdcb6745b06ea11d352d2e7
+  sha256: 943a046c1fe36b28b3cea11fb0d34e8b836b245433087f8fa916c0a752393181
 - type: file
   dest: .m2/repository/org/apache/xmlbeans/xmlbeans/5.2.1
   url: https://repo.maven.apache.org/maven2/org/apache/xmlbeans/xmlbeans/5.2.1/xmlbeans-5.2.1.jar
-  sha1: e16ddf17fe181c202b097e0dcc0ee2fed91cb7da
+  sha256: eff1746a43780845d625a3ceb137976d4665d01a71209507dc383c6f43ab288a
 - type: file
   dest: .m2/repository/org/apache/xmlbeans/xmlbeans/5.2.1
   url: https://repo.maven.apache.org/maven2/org/apache/xmlbeans/xmlbeans/5.2.1/xmlbeans-5.2.1.pom
-  sha1: a82bdf4757705bd1b925ece51010bb729fa7967b
+  sha256: ddfc207e6e31baab55777bd9bcabb9cb188576ce2622ce2d5f1e052e196792e8
 - type: file
   dest: .m2/repository/org/apiguardian/apiguardian-api/1.1.2
   url: https://repo.maven.apache.org/maven2/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar
-  sha1: a231e0d844d2721b0fa1b238006d15c6ded6842a
+  sha256: b509448ac506d607319f182537f0b35d71007582ec741832a1f111e5b5b70b38
 - type: file
   dest: .m2/repository/org/apiguardian/apiguardian-api/1.1.2
   url: https://repo.maven.apache.org/maven2/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.pom
-  sha1: ce9568cec632f7c99fb26d13c4d5c89517349f6b
+  sha256: 32355081d109095c3d5d374d5a43b4f4c1b75d549e983ef50723e2772e5302a0
 - type: file
   dest: .m2/repository/org/checkerframework/checker-compat-qual/2.5.3
   url: https://repo.maven.apache.org/maven2/org/checkerframework/checker-compat-qual/2.5.3/checker-compat-qual-2.5.3.jar
-  sha1: 045f92d2e0676d05ae9297269b8268f93a875d4a
+  sha256: d76b9afea61c7c082908023f0cbc1427fab9abd2df915c8b8a3e7a509bccbc6d
 - type: file
   dest: .m2/repository/org/checkerframework/checker-compat-qual/2.5.3
   url: https://repo.maven.apache.org/maven2/org/checkerframework/checker-compat-qual/2.5.3/checker-compat-qual-2.5.3.pom
-  sha1: cc075e163616b8284602e9fa9cadbd62b9c04374
+  sha256: f7fcdac99eb33d169f6d52a35541c22ffd14f458abbcf56f9c49ee1486598c9c
 - type: file
   dest: .m2/repository/org/checkerframework/checker-qual/3.33.0
   url: https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.33.0/checker-qual-3.33.0.pom
-  sha1: 6d43e2eacef053cffd73da56734e9a8a138b52be
+  sha256: f55a922027a78fdd8b3ea15a0d8bfe3fec6a5ceac30c86aa8afa4a5b9b0df603
 - type: file
   dest: .m2/repository/org/checkerframework/checker-qual/3.41.0
   url: https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.41.0/checker-qual-3.41.0.jar
-  sha1: 08be6df7f1e9bccb19f8f351b3651f0bac2f5e0c
+  sha256: 2f9f245bf68e4259d610894f2406dc1f6363dc639302bd566e8272e4f4541172
 - type: file
   dest: .m2/repository/org/checkerframework/checker-qual/3.41.0
   url: https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.41.0/checker-qual-3.41.0.pom
-  sha1: d9b04ef627d00ecaac9d19c101c100f686cfcc24
+  sha256: 5c73b0770540842cf06a01d264bbb89ae5e248669dc9da80e861e8233dd4675b
 - type: file
   dest: .m2/repository/org/checkerframework/checker-qual/3.43.0
   url: https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.43.0/checker-qual-3.43.0.jar
-  sha1: 9425eee39e56b116d2b998b7c2cebcbd11a3c98b
+  sha256: 3fbc2e98f05854c3df16df9abaa955b91b15b3ecac33623208ed6424640ef0f6
 - type: file
   dest: .m2/repository/org/checkerframework/checker-qual/3.43.0
   url: https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.43.0/checker-qual-3.43.0.pom
-  sha1: 48ad8955d64547b84ef581361c29c030e56430cb
+  sha256: 9313bf53b3efd8aaca266eea8b96e307976b65c0b16510cc6f02319fbaebed43
 - type: file
   dest: .m2/repository/org/codehaus/codehaus-parent/4
   url: https://repo.maven.apache.org/maven2/org/codehaus/codehaus-parent/4/codehaus-parent-4.pom
-  sha1: 8b133202d50bec1e59bddc9392cb44d1fe5facc8
+  sha256: 6b87237de8c2e1740cf80627c7f3ce3e15de1930bb250c55a1eca94fa3e014df
 - type: file
   dest: .m2/repository/org/codehaus/groovy/groovy-bom/3.0.21
   url: https://repo.maven.apache.org/maven2/org/codehaus/groovy/groovy-bom/3.0.21/groovy-bom-3.0.21.pom
-  sha1: 325a49f8c22e727d1682631ba68c99c32b2eaaa9
+  sha256: 92cc36affd20f568b5092c0b94ecf585ddeb0a281b6c8ba7256570bb185d6534
 - type: file
   dest: .m2/repository/org/codehaus/mojo/animal-sniffer-annotations/1.14
   url: https://repo.maven.apache.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.pom
-  sha1: 99a56e3312f8ece1d457c8ca0a3c4b69d173d000
+  sha256: 1879f19a05991e3ed95910b96689333396b0c467a215dc4d1f90018404b72a26
 - type: file
   dest: .m2/repository/org/codehaus/mojo/animal-sniffer-parent/1.14
   url: https://repo.maven.apache.org/maven2/org/codehaus/mojo/animal-sniffer-parent/1.14/animal-sniffer-parent-1.14.pom
-  sha1: c1e91a9c2f36d9e6d3c7087242d8d9ec56052e5d
+  sha256: f51550a06b1410bd4962cb0e71df0b921a60a7ef47bfa9c4825a14be72316eea
 - type: file
   dest: .m2/repository/org/codehaus/mojo/license-maven-plugin/2.5.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/mojo/license-maven-plugin/2.5.0/license-maven-plugin-2.5.0.jar
-  sha1: 269353bece3d8bc642f3bedcce1ab123b52f7fd8
+  sha256: 4520e9a62de03b1e32f4fc7d3046afc10507642cb4051372944934090155ad3c
 - type: file
   dest: .m2/repository/org/codehaus/mojo/license-maven-plugin/2.5.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/mojo/license-maven-plugin/2.5.0/license-maven-plugin-2.5.0.pom
-  sha1: a08764250af31be13eac3cecb073f8200e4cc6e4
+  sha256: 65578a1a1d8c16b2a8fae6d96a1ec617b56e9b0ffe95846d60f5147eb2dc04d3
 - type: file
   dest: .m2/repository/org/codehaus/mojo/mojo-parent/34
   url: https://repo.maven.apache.org/maven2/org/codehaus/mojo/mojo-parent/34/mojo-parent-34.pom
-  sha1: 803dc5cf36e504c5a48aa9a321f7fba1d6396733
+  sha256: 3e395d6fbc43c09a3774cac8694ce527398305ea3fd5492d80e25af27d382a9c
 - type: file
   dest: .m2/repository/org/codehaus/mojo/mojo-parent/86
   url: https://repo.maven.apache.org/maven2/org/codehaus/mojo/mojo-parent/86/mojo-parent-86.pom
-  sha1: 42fdf58ee4a09b9707dadad7ec86e0803c8ccb1c
+  sha256: 94e9ddc8f28d9d72f6ca8e191941ec20d4874bf8bd0db0fa4f051a16ce09734c
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus/1.0.10
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/1.0.10/plexus-1.0.10.pom
-  sha1: 039c3f6a3cbe1f9e7b4a3309d9d7062b6e390fa7
+  sha256: 09b999a969e73525a6cc3ad2868ea744766e1d93b25c6c656d61a5ff9c881da9
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus/1.0.11
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/1.0.11/plexus-1.0.11.pom
-  sha1: 4693d4512d50c5159bef1c49def1d2690a327c30
+  sha256: 5197630dcd2336f5b4ab8e6d26e5b8675f5ebd83bd8c91d6aba431b09627d626
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus/2.0.5
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/2.0.5/plexus-2.0.5.pom
-  sha1: c37b8e9129d8860dfdea27da2c5407de7c6faba7
+  sha256: 72b31dc11351a5bf4f5841221be5b1afc2b802ff96f23f2b77838f6d46cd3ad5
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus/2.0.6
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/2.0.6/plexus-2.0.6.pom
-  sha1: da193f47e5ce5a2cb85931851b3698e61cde8227
+  sha256: bea12e747708d25e73410ca1c731ebdfa102e8bdb6ec7d81bd4522583b234bcc
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus/5.1
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/5.1/plexus-5.1.pom
-  sha1: 2fca82e2eb5172f6a2909bea7accc733581a8c71
+  sha256: a343e44ff5796aed0ea60be11454c935ce20ab1c5f164acc8da574482dcbc7e9
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus/10
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/10/plexus-10.pom
-  sha1: d521749acee596e7325804c5b8fa208efa9f4263
+  sha256: bba9c521064b9ca132ce97cc1cc7eb4afc2dbe32bc88cb872c88e99f6162301f
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus/13
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/13/plexus-13.pom
-  sha1: 85676f789cc7204850a5c072c313a5ee228b0e0c
+  sha256: 575945dc08966c66eb03d5bae9135bd22ca3920a1865bb99d3ecd93bef55abd3
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus/16
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/16/plexus-16.pom
-  sha1: c81926f677c914cff35c0856a79e8713eea36f47
+  sha256: 68d4eed65a3dbbc342ed80dd138fbe9c67cb7fb4c2abc4f5201cdb5b9f645868
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus/17
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/17/plexus-17.pom
-  sha1: d902df7874c7a06b2be8ee03082e5af695250cf1
+  sha256: 91526ee66327c7f50fbb25bd41bfcb916e284414b868e31d50a23004bd7deea7
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus/18
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/18/plexus-18.pom
-  sha1: 6dcf47484abcaaa8288f528ccbde76171eb3c155
+  sha256: b43ee89c8890b9e5bc48d079fcb4c44f082b5139253356dc455806a33c3dd8fd
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus/19
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/19/plexus-19.pom
-  sha1: 68824feebcd60458f4abccd0ee02164631bc7ef1
+  sha256: 8d3e51c3902fd7596e548eab121ebf6b0d4aa73857077f26a24fc86f9b8455b4
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus/20
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/20/plexus-20.pom
-  sha1: 9868732b15c69f770fda48dca1ff5d9d43d35a3c
+  sha256: a7b594b002fc791733c8e94470d09045f4fd69a93ad5c375752f2057f84633b4
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-archiver/4.9.2
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/4.9.2/plexus-archiver-4.9.2.jar
-  sha1: a03ed402ef8468c1d1bda368d7213cad67f16a71
+  sha256: a837bd7d73291564dc8e8c826de0fede75896527a35bdcddb77b0545ee656a4c
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-archiver/4.9.2
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/4.9.2/plexus-archiver-4.9.2.pom
-  sha1: 7d735c23385b28f42fffacbbb11c6cd3b9820227
+  sha256: 7b4a569c92f60c859ae69594f8935d11bcbb940d86c518742c30f0925a48ba9f
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-archiver/4.10.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/4.10.0/plexus-archiver-4.10.0.jar
-  sha1: d63e385ae6ded05eef954102f0cd1137b2baab81
+  sha256: 4c07814ff4a39199999ae82bba1e38aa4f25637467fcac6a66ed63a76535799a
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-archiver/4.10.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/4.10.0/plexus-archiver-4.10.0.pom
-  sha1: b6287c006a044ef19d42dc3f7da5e67db85e0fb2
+  sha256: 93ca001fd33da53d38b74f6daf19e71bc9736ed6143091ff9003cd4c05ace6c9
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-classworlds/2.2.3
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.2.3/plexus-classworlds-2.2.3.pom
-  sha1: 068f7ac6a425f5e82bbbb5faef91e4b5d3d84f76
+  sha256: a2d14b6752e30a100a6cb03c040d0160b71b61928daf8ea97cabfb4a3335b213
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-classworlds/2.6.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.6.0/plexus-classworlds-2.6.0.jar
-  sha1: 8587e80fcb38e70b70fae8d5914b6376bfad6259
+  sha256: 52f77c5ec49f787c9c417ebed5d6efd9922f44a202f217376e4f94c0d74f3549
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-classworlds/2.6.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.6.0/plexus-classworlds-2.6.0.pom
-  sha1: e05bc927ead7a1e7dc36c7daed209611d94fbb6d
+  sha256: 469a6c59f92effa62c0797ce7d52d2c03cf8ee1034b923c360dd78a9f505a7ba
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-compiler/2.15.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler/2.15.0/plexus-compiler-2.15.0.pom
-  sha1: a6e6866e422252517e7d3d37097117c09b369b99
+  sha256: 9c9b62a7703d4994b60fb7f9e42805f9abc798d1397e4d22c1118cd12aa678d8
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-compiler-api/2.15.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-api/2.15.0/plexus-compiler-api-2.15.0.jar
-  sha1: 1bd59395d358ca695fddc7b9dc594483f4140601
+  sha256: d31d744eb69f77dffd3722dca4094758e0f90e79918a7b3b9fdc37ce49b60342
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-compiler-api/2.15.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-api/2.15.0/plexus-compiler-api-2.15.0.pom
-  sha1: 85362b884310a05ede00e892923492aa7e96c9f1
+  sha256: 4c89cab0505b0ac901197d2dd1363fe5e26bcbfd43e99dd21a8ae023b443cc4e
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-compiler-javac/2.15.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-javac/2.15.0/plexus-compiler-javac-2.15.0.jar
-  sha1: 48069fe3c512b09e8aa32d77929c190a6faba790
+  sha256: 89603334988453b9cf4d7ec404d4b54f140de28b678d6a8e8edc448240dd0e90
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-compiler-javac/2.15.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-javac/2.15.0/plexus-compiler-javac-2.15.0.pom
-  sha1: e391b900f6ace61b0c6dcd650afb6834b706ceca
+  sha256: bbe796c5fe109736980aff79860548d828abd27b36872b80a0e831642b65f328
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-compiler-manager/2.15.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-manager/2.15.0/plexus-compiler-manager-2.15.0.jar
-  sha1: 4c6d2fc56063e2c62b953a2da9ad60c19097474d
+  sha256: c13b12c32a18b00e457de9b93cfc3d5593bfa1fb992b2c46a3498be1a77c4889
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-compiler-manager/2.15.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-manager/2.15.0/plexus-compiler-manager-2.15.0.pom
-  sha1: 05e0554068987c383fcd50d94a663421b341c5f0
+  sha256: 12bd3bfb803d2004ed8318583ac7b272115a8b9303eabcd100808c54d44d2017
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-compilers/2.15.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compilers/2.15.0/plexus-compilers-2.15.0.pom
-  sha1: 26209faddddf2bbd50e438962d6f89059daba8fc
+  sha256: 1ce14d30276866a9493a2c72e42f990a2e3c1bd794026ccd9830475a12d9a91d
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-component-annotations/1.5.4
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.5.4/plexus-component-annotations-1.5.4.pom
-  sha1: 52093f92fd7f82edf464f86c4f7220f9effc4bf2
+  sha256: 0124227bc47efc9a00b9aa4fc3ef7f70823d322213c26489e5369a914339c84a
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-component-annotations/2.0.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/2.0.0/plexus-component-annotations-2.0.0.jar
-  sha1: 6897b9fa8b67c900b52996f845e2d179eea13441
+  sha256: 405eef6fc9188241ec88579c3e473f5c8997455c69bcd62e142492aca15106bc
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-component-annotations/2.0.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/2.0.0/plexus-component-annotations-2.0.0.pom
-  sha1: c273519bf9d766461c523facbf530ba18793bbe4
+  sha256: dcf193612b315713771e267b42de2d44de090be5945b2577345ed5ab8de2d271
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-component-annotations/2.1.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/2.1.0/plexus-component-annotations-2.1.0.jar
-  sha1: 2f2147a6cc6a119a1b51a96f31d45c557f6244b9
+  sha256: bde3617ce9b5bcf9584126046080043af6a4b3baea40a3b153f02e7bbc32acac
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-component-annotations/2.1.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/2.1.0/plexus-component-annotations-2.1.0.pom
-  sha1: b86c9acce33ef506e0cef3692ebc784df0db195a
+  sha256: 0670b605255f7dc9a454daaec7912918ccf1b5475cbfca374363b51fcfd4ea00
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-components/1.1.12
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.12/plexus-components-1.1.12.pom
-  sha1: e7332a35914684bab5dd1718aea0202fa5a2bb0d
+  sha256: a854365061c28821ddf1a520b8a197991613fd1d56f50f42c468b789b4714f20
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-containers/1.5.4
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.5.4/plexus-containers-1.5.4.pom
-  sha1: b9942b081e9903371eb0c8f5677d1d2564b575ca
+  sha256: 18b4a1b0a65c0d6b7cf9cd48ee9f3467b6deb8ace4c1309522c184f94c4cfa2e
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-containers/2.0.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/2.0.0/plexus-containers-2.0.0.pom
-  sha1: 47ae11db323292909afbcbd817f9cafda054000a
+  sha256: be5e3f8e59edce852a0fdaef8caedb32f364bf13db654d15f98e17930e456487
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-containers/2.1.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/2.1.0/plexus-containers-2.1.0.pom
-  sha1: 133ad2d4fca8f498be182d776e85f359f7ac6e36
+  sha256: 94d5aedb3c46023265396527cf8ce7fc944b7bd79e4ebab907386418eb5a08d7
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-i18n/1.0-beta-10
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-i18n/1.0-beta-10/plexus-i18n-1.0-beta-10.jar
-  sha1: 27506f59e54cc80b8c28b977c2bcd0478094e0cc
+  sha256: b87f25b512ffafcafbf4a05ab943812e9c6915291370c6b46016eb3836886c41
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-i18n/1.0-beta-10
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-i18n/1.0-beta-10/plexus-i18n-1.0-beta-10.pom
-  sha1: d7865049eee42a4c87888fd1e762e9b8d864a78d
+  sha256: 4073a94aadf4d511d85bce597c09f8e9355a458ccbb07f2ed82f4c39303fe374
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-interpolation/1.26
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.26/plexus-interpolation-1.26.jar
-  sha1: 25b919c664b79795ccde0ede5cee0fd68b544197
+  sha256: b3b5412ce17889103ea564bcdfcf9fb3dfa540344ffeac6b538a73c9d7182662
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-interpolation/1.26
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.26/plexus-interpolation-1.26.pom
-  sha1: af412be9edee5aad63bbb304752ac0deda35ff08
+  sha256: e1c10b3a6335641eb74a668daa9ee86ae4ab06610174e59ba07c8c68042327f7
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-interpolation/1.27
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.27/plexus-interpolation-1.27.jar
-  sha1: 8dc73f4ff5eafcbb7ec035ba54736e828b272533
+  sha256: 3fb4fb6143fdf964024c3cb738551524b9ea84e5c211cd660c559ad0703e5230
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-interpolation/1.27
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.27/plexus-interpolation-1.27.pom
-  sha1: 0562449f7a1f2ec670751e294799e8786f8003e3
+  sha256: d54fbcbc4399e352322874a4128b9d28fe9fe1583f89ec361de242ea38d33f9b
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-io/3.4.2
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/3.4.2/plexus-io-3.4.2.jar
-  sha1: 40deb3076e4597f1ef973dc794f3a510fa3a942d
+  sha256: 6ba7fb0db6bfa348c248df3f983ae31318e9c14f35a86a932af5ffd7450aa62a
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-io/3.4.2
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/3.4.2/plexus-io-3.4.2.pom
-  sha1: 4faed3a6992fff12755fdb541824d809a6add4ee
+  sha256: aafc90ce29fe79bc6a0aeafb2bf6bdeaf979a1b8211493428a2290228170355d
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-io/3.5.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/3.5.0/plexus-io-3.5.0.jar
-  sha1: dff8fd2ddb661a4b6b0f9587589ea00dc97605e6
+  sha256: 965ed28912cf1ae4c628112c4009e0c19819bc44ed5db8af54ee5eda21036a3e
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-io/3.5.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/3.5.0/plexus-io-3.5.0.pom
-  sha1: c06dca0b2993be2cdd99437d4031500e23ea116c
+  sha256: f5b86cd223a0bf4ba649de19e7e8e4e1f14344ff636f8b0024c89c46d28cc9d8
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-io/3.5.1
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/3.5.1/plexus-io-3.5.1.jar
-  sha1: 4a1cf4de1aae5a6906795e30f437f94dd4176f68
+  sha256: 30c29c1fe7552d606728d3724c2aafcc577d738fe71cd17194a8b957adb34856
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-io/3.5.1
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/3.5.1/plexus-io-3.5.1.pom
-  sha1: 108b611fb4f8653e749f609643fd1e161e5e3046
+  sha256: f7a76d3a3bbeb53f5f36e19ee57ddc2099f3be1d599039090254d1f0fdf0b854
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-java/1.4.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/1.4.0/plexus-java-1.4.0.jar
-  sha1: 85efa6e13ef450deb94f6cb0a812a4e7acf74009
+  sha256: e295f379d7885edec5d9501ee0a9152300359167f875dc7c483305c9799d70d0
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-java/1.4.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/1.4.0/plexus-java-1.4.0.pom
-  sha1: 132cb99064e47a034a993d9501578c82d0d08b34
+  sha256: 7ea67667477f8bcf54725101af638778240931c7c7ff84fe81515936517dcd98
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-languages/1.4.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-languages/1.4.0/plexus-languages-1.4.0.pom
-  sha1: 5ee78cd8c1813e574d13452742c2b0ac43346cb9
+  sha256: 2bc01c343a5cc9a2fdffc6b9b83d4cc03fbe8fd51ba09e94d2139106649a66d4
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/1.4.5
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.4.5/plexus-utils-1.4.5.pom
-  sha1: 0bdc8a7fbce7d9007a93d289a029b43e1196d85c
+  sha256: 687d05a9521ecb8e319e6beb46abcf53e0e61be647f1c7642a86e22f46814336
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/3.5.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.5.0/plexus-utils-3.5.0.pom
-  sha1: 5b0a95ee86f9182f8e01ff878fc7e39dd841bc49
+  sha256: aa4ea451bb6fa92e9cc96654eef53e334ff4d36a946633e01765fed41e845e03
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/3.5.1
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.5.1/plexus-utils-3.5.1.jar
-  sha1: c6bfb17c97ecc8863e88778ea301be742c62b06d
+  sha256: 86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/3.5.1
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.5.1/plexus-utils-3.5.1.pom
-  sha1: 9b1bf6967abaa0a516a04ea096da08ec8d8fe0d7
+  sha256: 94ff68edeb48204d12c99189c767164d3a9f778a1372d1dce11a41462e6236f2
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/4.0.1
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/4.0.1/plexus-utils-4.0.1.jar
-  sha1: 2162c639aa9b081ef2a0be9d41643513e284bf99
+  sha256: 96b9cc44439191d2d0635974e2d44e768736b4fb2abcb65f94cd95e41912fa8b
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/4.0.1
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/4.0.1/plexus-utils-4.0.1.pom
-  sha1: e0676726100b880bfb6e317ee364e953b77c1a93
+  sha256: bc4235a95cd1ebae42644c81ebba9c1d4c52565f81e96ab204b6e56e3e378cc1
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/4.0.2
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/4.0.2/plexus-utils-4.0.2.jar
-  sha1: 9526a9548b302572f23337fcc217fb4cc713b9c3
+  sha256: 8957274e75fe2c278b1428dd16a0daeee1dd38152cb6eff816177ac28fccb697
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/4.0.2
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/4.0.2/plexus-utils-4.0.2.pom
-  sha1: 90bdd43cc00d6fc5509e53bf09268e33708c5e8b
+  sha256: 5151c13bdd7cc3a5569583a7f4267392f013ffd3115eab8db5f86de420a366af
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-velocity/2.2.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-velocity/2.2.0/plexus-velocity-2.2.0.jar
-  sha1: 75a983b74a4c0adcd0751528ff397ae308ef6d0c
+  sha256: 3e7e902f492c973cf210ddb8267843a3b65e83f5067467e2f4d9af0051f6b8b9
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-velocity/2.2.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-velocity/2.2.0/plexus-velocity-2.2.0.pom
-  sha1: b3fe96aae14b0c044801dde3b9d2b92dfb9a47b0
+  sha256: 6f6a9b05f40e8e84af4aa9576f6b1e435ded6d5b56931b2a269b697bf72ce49d
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-xml/3.0.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-xml/3.0.0/plexus-xml-3.0.0.pom
-  sha1: f94a34d43206e704670533b74feb981b8de56640
+  sha256: c07d67161cdf7f8fdce4cd921be5d3cccb9e2c259105ca1afeb772cbcb0cbec5
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-xml/3.0.1
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-xml/3.0.1/plexus-xml-3.0.1.jar
-  sha1: b0e73c21402f03c2765674b8dede21673b3288cf
+  sha256: c1a510a87a62bd2d74ac1472dd31c3f9e9b0b8b8568f37d77c0f135415bebd05
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-xml/3.0.1
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-xml/3.0.1/plexus-xml-3.0.1.pom
-  sha1: 589c7ceee7c159b87aea44a4de757a4cd9c81956
+  sha256: 3242ddc20873f71b381c333b22afb9cf3596d6a63b6683036a16bd51bc8721a4
 - type: file
   dest: .m2/repository/org/cryptomator/cryptofs/2.9.0
   url: https://repo.maven.apache.org/maven2/org/cryptomator/cryptofs/2.9.0/cryptofs-2.9.0.jar
-  sha1: dde8c6d8e597b991eb8a883d3ba0993e96d85539
+  sha256: 98a40fd57004b323fcc3b57a8d0e889bae20c9489aa8eeaafc1eebb3357e7c55
 - type: file
   dest: .m2/repository/org/cryptomator/cryptofs/2.9.0
   url: https://repo.maven.apache.org/maven2/org/cryptomator/cryptofs/2.9.0/cryptofs-2.9.0.pom
-  sha1: be598bcd5886c8877e8d2ebd709ed248c54be010
+  sha256: f5a305c4dadccf67c74fd4ea2ca3913be29cd3161fadd450e900b65d848469da
 - type: file
   dest: .m2/repository/org/cryptomator/cryptolib/2.2.1
   url: https://repo.maven.apache.org/maven2/org/cryptomator/cryptolib/2.2.1/cryptolib-2.2.1.jar
-  sha1: 7c2ad63fa956cb4605b4c158df2fca9591035904
+  sha256: e9dabc036e086f4d06bb0a23d0d6b5fd83f7723622018790b6e9a06d3e2fa64b
 - type: file
   dest: .m2/repository/org/cryptomator/cryptolib/2.2.1
   url: https://repo.maven.apache.org/maven2/org/cryptomator/cryptolib/2.2.1/cryptolib-2.2.1.pom
-  sha1: 2b9c031a2924c852405390d15a1e5f87e4f234df
+  sha256: 04e7f05aadd947b6d9bb40183d8011453033b367138a85955c0f667f12ffb22e
 - type: file
   dest: .m2/repository/org/cryptomator/fuse-nio-adapter/5.0.5
   url: https://repo.maven.apache.org/maven2/org/cryptomator/fuse-nio-adapter/5.0.5/fuse-nio-adapter-5.0.5.jar
-  sha1: 9db50fc4438d5fb70f80321080f6e6fbc4e4912f
+  sha256: dc8a84c30ec36f17708108056ec6e5753ef822f078b1d61931f6d2970cf8672b
 - type: file
   dest: .m2/repository/org/cryptomator/fuse-nio-adapter/5.0.5
   url: https://repo.maven.apache.org/maven2/org/cryptomator/fuse-nio-adapter/5.0.5/fuse-nio-adapter-5.0.5.pom
-  sha1: 48dee25adb248afd552203821ec515031e0301ba
+  sha256: 2c0042454a693b5620c1960ed0cfff5d29047ac490a84318d22e04fb4f64f8d6
 - type: file
   dest: .m2/repository/org/cryptomator/integrations-api/1.5.1
   url: https://repo.maven.apache.org/maven2/org/cryptomator/integrations-api/1.5.1/integrations-api-1.5.1.pom
-  sha1: b66c90f6587320bdbfbd1d9e97493706bfb1b044
+  sha256: 55d0c2e9ba7610d007c17fd39749a4bd311d3e3ae02427232449f1f142a5e3a6
 - type: file
   dest: .m2/repository/org/cryptomator/integrations-api/1.6.0
   url: https://repo.maven.apache.org/maven2/org/cryptomator/integrations-api/1.6.0/integrations-api-1.6.0.jar
-  sha1: f8d3e5c99de8cea7b0dc0d0c87abde2fdbd816de
+  sha256: 09f52304f2534b1097456fb61c7fdba4ac24a27e5adad467e885442d50f8da8d
 - type: file
   dest: .m2/repository/org/cryptomator/integrations-api/1.6.0
   url: https://repo.maven.apache.org/maven2/org/cryptomator/integrations-api/1.6.0/integrations-api-1.6.0.pom
-  sha1: 13bca427266c01c73d45b28c4b1eee2177382258
+  sha256: 0746787699cfd2bd0b18670b5aca07fd94ca1df863787bb77185c29833d6ed5e
 - type: file
   dest: .m2/repository/org/cryptomator/integrations-linux/1.6.0
   url: https://repo.maven.apache.org/maven2/org/cryptomator/integrations-linux/1.6.0/integrations-linux-1.6.0.jar
-  sha1: c880714824fa7bda74dbe8415698dfbb1a0a610c
+  sha256: b465cd2beca18aa4cc7e722cf7e2e002c05f9f4c6a735efb1e202f08bfa6e971
 - type: file
   dest: .m2/repository/org/cryptomator/integrations-linux/1.6.0
   url: https://repo.maven.apache.org/maven2/org/cryptomator/integrations-linux/1.6.0/integrations-linux-1.6.0.pom
-  sha1: a3d1b2e3ebb2eb0e53f08f67fe8da5f365486a7d
+  sha256: c8eca581f2c491dfdec6ff47f9d3a9a56661754ef0118555c8c0f5c5a4dcf2ba
 - type: file
   dest: .m2/repository/org/cryptomator/jfuse/0.7.3
   url: https://repo.maven.apache.org/maven2/org/cryptomator/jfuse/0.7.3/jfuse-0.7.3.jar
-  sha1: de945c064f817fa692f411f0728c4430d9977319
+  sha256: dd2a86913383de9ddcc737f813ef712f0e5157964107a6f77ab88e540fc2f72e
 - type: file
   dest: .m2/repository/org/cryptomator/jfuse/0.7.3
   url: https://repo.maven.apache.org/maven2/org/cryptomator/jfuse/0.7.3/jfuse-0.7.3.pom
-  sha1: ff6d394dc6f8b0bff11678a10af38eacc445c66c
+  sha256: ffc0b7283d4263979fc5168e582cf4c32fbee36321b7359cc232741612155cd0
 - type: file
   dest: .m2/repository/org/cryptomator/jfuse-api/0.7.3
   url: https://repo.maven.apache.org/maven2/org/cryptomator/jfuse-api/0.7.3/jfuse-api-0.7.3.jar
-  sha1: df2e04b62c14076fb4a4ca234b4b3c6e5d50c04b
+  sha256: 856d758fbe74a376080f7e84ad12c0dc721327da43f0b66fd85ff01d89c3772c
 - type: file
   dest: .m2/repository/org/cryptomator/jfuse-api/0.7.3
   url: https://repo.maven.apache.org/maven2/org/cryptomator/jfuse-api/0.7.3/jfuse-api-0.7.3.pom
-  sha1: 10374c2a60235820eb8e39c61aab5db4b0ae1573
+  sha256: 13bb211631c2454732f198a9e62ae5671daa85e20dbd543cd3eb5b4209bab04f
 - type: file
   dest: .m2/repository/org/cryptomator/jfuse-linux-aarch64/0.7.3
   url: https://repo.maven.apache.org/maven2/org/cryptomator/jfuse-linux-aarch64/0.7.3/jfuse-linux-aarch64-0.7.3.jar
-  sha1: e842784f831966348690799d06d4f7dc3a7b8c9d
+  sha256: 1ad5b3a92ce5c05cd5334bcecc589bf6ab9944b79082978e8480647ec6cf32a8
 - type: file
   dest: .m2/repository/org/cryptomator/jfuse-linux-aarch64/0.7.3
   url: https://repo.maven.apache.org/maven2/org/cryptomator/jfuse-linux-aarch64/0.7.3/jfuse-linux-aarch64-0.7.3.pom
-  sha1: 83cc58c17daf467d9e8ad0b53217cff07ffc1a4e
+  sha256: 4152779245c1cb1c2daf16416e351ecd620a0d5af9ce251943c1f7c97063d295
 - type: file
   dest: .m2/repository/org/cryptomator/jfuse-linux-amd64/0.7.3
   url: https://repo.maven.apache.org/maven2/org/cryptomator/jfuse-linux-amd64/0.7.3/jfuse-linux-amd64-0.7.3.jar
-  sha1: 128796091ae9dd5810a0581a409fc7a30e93180a
+  sha256: 29b1a8ba69c5e7cdb1f499850cf670ac2d2b490471913b87a721fba1fe3ae972
 - type: file
   dest: .m2/repository/org/cryptomator/jfuse-linux-amd64/0.7.3
   url: https://repo.maven.apache.org/maven2/org/cryptomator/jfuse-linux-amd64/0.7.3/jfuse-linux-amd64-0.7.3.pom
-  sha1: 395e1646d955443300927001a60b8610b4683bdb
+  sha256: d3baa0008a57e86f3e95f50657d3d3e2226f899baf5b3b0e74b23a9cfa3c8a6b
 - type: file
   dest: .m2/repository/org/cryptomator/jfuse-mac/0.7.3
   url: https://repo.maven.apache.org/maven2/org/cryptomator/jfuse-mac/0.7.3/jfuse-mac-0.7.3.jar
-  sha1: 9e32c5e62c9a5b5d552b8484e89116418ae63d3d
+  sha256: b5201a73e1dc4a98b5acc8822a929c98e0f25802a6af25bbfbb3f80815b2eafa
 - type: file
   dest: .m2/repository/org/cryptomator/jfuse-mac/0.7.3
   url: https://repo.maven.apache.org/maven2/org/cryptomator/jfuse-mac/0.7.3/jfuse-mac-0.7.3.pom
-  sha1: 2623dc92abecd1cb3a03e0825908a1f4b7983553
+  sha256: 50ae66dfd50c0740d3423f62c339360f8ee3c661f1709f74f99ecea787bc1acb
 - type: file
   dest: .m2/repository/org/cryptomator/jfuse-parent/0.7.3
   url: https://repo.maven.apache.org/maven2/org/cryptomator/jfuse-parent/0.7.3/jfuse-parent-0.7.3.pom
-  sha1: 89a11f9953137dee95b50cc77e942328add98e4f
+  sha256: f841879ed4e9cd876bf49a0e5837f0cc49e15d1f277306ef5ac72ff9355e24c3
 - type: file
   dest: .m2/repository/org/cryptomator/jfuse-win/0.7.3
   url: https://repo.maven.apache.org/maven2/org/cryptomator/jfuse-win/0.7.3/jfuse-win-0.7.3.jar
-  sha1: 850a35b4e196f499ad2571f6020ae685e30a1e91
+  sha256: 964e40b6079f661239b8d67d2f10c4978710dc6d028a71a619901722212e3375
 - type: file
   dest: .m2/repository/org/cryptomator/jfuse-win/0.7.3
   url: https://repo.maven.apache.org/maven2/org/cryptomator/jfuse-win/0.7.3/jfuse-win-0.7.3.pom
-  sha1: 8ed45438d59bc3d6214894f0224b658300c52055
+  sha256: 54824708fa518de8567b982b0e9bffce811091cca64fd6ecf991b7127dfdc991
 - type: file
   dest: .m2/repository/org/cryptomator/siv-mode/1.6.1
   url: https://repo.maven.apache.org/maven2/org/cryptomator/siv-mode/1.6.1/siv-mode-1.6.1.jar
-  sha1: df8ab9b8cf53317cabb97157a3a6e2f4b2866eab
+  sha256: 7d2b927818d981bd5549fb522d0df7b47522b1fde9c1a7b120965ea41e4f84d2
 - type: file
   dest: .m2/repository/org/cryptomator/siv-mode/1.6.1
   url: https://repo.maven.apache.org/maven2/org/cryptomator/siv-mode/1.6.1/siv-mode-1.6.1.pom
-  sha1: 558ca243daddcf1f630d5db4c55416537790adb6
+  sha256: b7f7b26bdaf9d42376a0a80f7b0bc5d23f530f36d333fdd87986516b19795873
 - type: file
   dest: .m2/repository/org/cryptomator/webdav-nio-adapter/2.0.10
   url: https://repo.maven.apache.org/maven2/org/cryptomator/webdav-nio-adapter/2.0.10/webdav-nio-adapter-2.0.10.jar
-  sha1: 84735f1c62191409ea8c1a57b10383864eccbace
+  sha256: 2abd569059b0855a9e4535094a977e46e28185d740cbb4dab21a1efd5c03336d
 - type: file
   dest: .m2/repository/org/cryptomator/webdav-nio-adapter/2.0.10
   url: https://repo.maven.apache.org/maven2/org/cryptomator/webdav-nio-adapter/2.0.10/webdav-nio-adapter-2.0.10.pom
-  sha1: c8bbf4cdcd7e0e2bc95c673e91105432fb780dd6
+  sha256: 7edd112acc6956e80f7e1405b8153bd5c9c93e316567c237437829e5a25e693b
 - type: file
   dest: .m2/repository/org/cryptomator/webdav-nio-adapter-servlet/1.2.9
   url: https://repo.maven.apache.org/maven2/org/cryptomator/webdav-nio-adapter-servlet/1.2.9/webdav-nio-adapter-servlet-1.2.9.jar
-  sha1: 9e37464a3544c2d072c51daced6b9bf5a5d9da14
+  sha256: 49c4d4becd639808b4db836e59a613e64db8bf7485f43be241f76be1c547b246
 - type: file
   dest: .m2/repository/org/cryptomator/webdav-nio-adapter-servlet/1.2.9
   url: https://repo.maven.apache.org/maven2/org/cryptomator/webdav-nio-adapter-servlet/1.2.9/webdav-nio-adapter-servlet-1.2.9.pom
-  sha1: 905d633e870a77e2bdf18d83728c99ed3c7720f6
+  sha256: 064c2ca1e06cca1954ba9f1fc9e4d5593996424f25f62f8ed3e96f3fa98682a0
 - type: file
   dest: .m2/repository/org/eclipse/ee4j/project/1.0.6
   url: https://repo.maven.apache.org/maven2/org/eclipse/ee4j/project/1.0.6/project-1.0.6.pom
-  sha1: 9adda6d67ddf76eb9ed4e1c331d705d03dc2a94b
+  sha256: 4e7d8329d8da7dcf30779d824241be145f27108932f5a5a24eb907677bc8d72d
 - type: file
   dest: .m2/repository/org/eclipse/ee4j/project/1.0.7
   url: https://repo.maven.apache.org/maven2/org/eclipse/ee4j/project/1.0.7/project-1.0.7.pom
-  sha1: b0f6c4bc691a0b694a377edc9bc4777871647253
+  sha256: 205c039a42cbae3556efbeb04a483eb3a3cf9550bd75bf84260dc8f28218f105
 - type: file
   dest: .m2/repository/org/eclipse/jetty/jetty-bom/9.4.54.v20240208
   url: https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-bom/9.4.54.v20240208/jetty-bom-9.4.54.v20240208.pom
-  sha1: ce7382fb18185685b0787387b61a960bbdcbb730
+  sha256: d344104a6ee619da6598403c25d03aaaaaf0f54e9646fd3512458df57c9aaeb8
 - type: file
   dest: .m2/repository/org/eclipse/jetty/jetty-http/10.0.25
   url: https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-http/10.0.25/jetty-http-10.0.25.jar
-  sha1: eaa6cd99b9ec7977ae07b2563f598ea0e31130ab
+  sha256: 31d196f8292f9d66e4164be27335840a9564ca9274b327c0ee1ec840e4f17e63
 - type: file
   dest: .m2/repository/org/eclipse/jetty/jetty-http/10.0.25
   url: https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-http/10.0.25/jetty-http-10.0.25.pom
-  sha1: 7b81bbd0e1aa87d095b07256959d7eb0f96f254f
+  sha256: 3ee4d5031e6bd262fc5d4167ae1e5ec57990543821ed902a42f4f1a43258d87a
 - type: file
   dest: .m2/repository/org/eclipse/jetty/jetty-io/10.0.25
   url: https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-io/10.0.25/jetty-io-10.0.25.jar
-  sha1: 114d3abc13e65783581e7ec2235378069c5f33ed
+  sha256: c9a9de636ccbb8946bb40506741e7e40b2ecba1f630479c823a611fb2c717bec
 - type: file
   dest: .m2/repository/org/eclipse/jetty/jetty-io/10.0.25
   url: https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-io/10.0.25/jetty-io-10.0.25.pom
-  sha1: d9f0de218ec3bc51494733321430b967ef44ab5f
+  sha256: 0476323c5ba78eb3b40629c9d731c10416774abbd211d65f40991e1f2a043ae3
 - type: file
   dest: .m2/repository/org/eclipse/jetty/jetty-project/10.0.25
   url: https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-project/10.0.25/jetty-project-10.0.25.pom
-  sha1: 665232b352d868fd0b06adf5e7227e34d1b41566
+  sha256: 0c252e857c0a9bc3e62798a2e8c7b7f3faab2e1d81cc033be4ee3146dc378be8
 - type: file
   dest: .m2/repository/org/eclipse/jetty/jetty-security/10.0.25
   url: https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-security/10.0.25/jetty-security-10.0.25.jar
-  sha1: 685d9c360301f5683ac762b81c8fb83b1ff4502d
+  sha256: f5bcc385c26e57a39433302b67041536a2737726f78ec4cded708906c8f2c463
 - type: file
   dest: .m2/repository/org/eclipse/jetty/jetty-security/10.0.25
   url: https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-security/10.0.25/jetty-security-10.0.25.pom
-  sha1: 08520f239cafbd13e2c9617cdf5cc48d00481a50
+  sha256: b948556287e4bb49ae099d1d3012f5871b3e12b3efc6f8ec3b697f3bd5efe5f7
 - type: file
   dest: .m2/repository/org/eclipse/jetty/jetty-server/10.0.25
   url: https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-server/10.0.25/jetty-server-10.0.25.jar
-  sha1: c756438486556cb56fe32e1ff9bfe72e7c70ad77
+  sha256: 7d4becb0279e47d3d5f207ef2c45f3d0c67d4567640f70e3cc8e9fbd9343d8fc
 - type: file
   dest: .m2/repository/org/eclipse/jetty/jetty-server/10.0.25
   url: https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-server/10.0.25/jetty-server-10.0.25.pom
-  sha1: 071c5fe8f799e9b304e2d525903dcdb82dfd1cff
+  sha256: 02ef7323cc828fc65637e7c219c8646edd154d2a595f5c847a55d278cde16253
 - type: file
   dest: .m2/repository/org/eclipse/jetty/jetty-servlet/10.0.25
   url: https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-servlet/10.0.25/jetty-servlet-10.0.25.jar
-  sha1: 16902f9d4c2144df960d2a5eed36929f3080b022
+  sha256: ff75a325a5842f15cf3933f08997a8da42a2499dc8564a41f68158d6ae07e455
 - type: file
   dest: .m2/repository/org/eclipse/jetty/jetty-servlet/10.0.25
   url: https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-servlet/10.0.25/jetty-servlet-10.0.25.pom
-  sha1: e89dc6df5479709f27e5a98fec02837633ad352f
+  sha256: e44983a737ebd2be8ccdc1861080f1163210086a40abf822cb56357a8e4d88ed
 - type: file
   dest: .m2/repository/org/eclipse/jetty/jetty-util/10.0.25
   url: https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-util/10.0.25/jetty-util-10.0.25.jar
-  sha1: 476d6db3ea9c13740b74e3d70e86c3890522e9bb
+  sha256: 2df7c0760d97ec58094babec6a8e48963e4c3b40628e1864bb8cde018d805607
 - type: file
   dest: .m2/repository/org/eclipse/jetty/jetty-util/10.0.25
   url: https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-util/10.0.25/jetty-util-10.0.25.pom
-  sha1: 763de41c42ec248dc1ca00836bdb57938ee60b6c
+  sha256: eb70c8b165b538762f7227b73f2c324c9bfe9af67e5c4296830478fe254adef5
 - type: file
   dest: .m2/repository/org/eclipse/jetty/toolchain/jetty-servlet-api/4.0.6
   url: https://repo.maven.apache.org/maven2/org/eclipse/jetty/toolchain/jetty-servlet-api/4.0.6/jetty-servlet-api-4.0.6.jar
-  sha1: 959c5d83d08f5cddf56caff749e48b735193191b
+  sha256: d90bf1f8a9d2ba89f4510bb51e1516dcf94ef6dc034e00f233654abdd78f2210
 - type: file
   dest: .m2/repository/org/eclipse/jetty/toolchain/jetty-servlet-api/4.0.6
   url: https://repo.maven.apache.org/maven2/org/eclipse/jetty/toolchain/jetty-servlet-api/4.0.6/jetty-servlet-api-4.0.6.pom
-  sha1: 22cfd685e957e7920fbf44ad85b88cb5314a5af5
+  sha256: 28a224eef46983c7d06c9062f0b64f778992f0fbf6bdd416a3f983162fe87b57
 - type: file
   dest: .m2/repository/org/eclipse/jetty/toolchain/jetty-toolchain/1.7
   url: https://repo.maven.apache.org/maven2/org/eclipse/jetty/toolchain/jetty-toolchain/1.7/jetty-toolchain-1.7.pom
-  sha1: e11631c50f449f6cddb05d36b8ec832d21bca2e4
+  sha256: 7c1532622470a0ccab07e06c6c58290ff1b25836acf2dc5e7a91a8d6d87a58ee
 - type: file
   dest: .m2/repository/org/eclipse/sisu/org.eclipse.sisu.inject/0.9.0.M3
   url: https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/0.9.0.M3/org.eclipse.sisu.inject-0.9.0.M3.jar
-  sha1: 3665002ba4d16dfa779ef658a63d0608c4bd898b
+  sha256: 15335c4dcf082f599fb8eddcfb58d6a7e9a9c97de2883c257089a479b9b24522
 - type: file
   dest: .m2/repository/org/eclipse/sisu/org.eclipse.sisu.inject/0.9.0.M3
   url: https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/0.9.0.M3/org.eclipse.sisu.inject-0.9.0.M3.pom
-  sha1: 6d96c7fc5c1d67ea1e3a92faac914aa51215e8b8
+  sha256: 57ed17e057ba716cc1f1e5b2d4e014a68c3d50bd33498227a90f712519334dd4
 - type: file
   dest: .m2/repository/org/eclipse/sisu/org.eclipse.sisu.plexus/0.9.0.M3
   url: https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.plexus/0.9.0.M3/org.eclipse.sisu.plexus-0.9.0.M3.jar
-  sha1: b493c7abcc6e04fa0a6a20d489a3db0395c76f70
+  sha256: c99674d3773e26154885661711f0b6d63aa5008f5cc99227a236756d4ad9de5e
 - type: file
   dest: .m2/repository/org/eclipse/sisu/org.eclipse.sisu.plexus/0.9.0.M3
   url: https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.plexus/0.9.0.M3/org.eclipse.sisu.plexus-0.9.0.M3.pom
-  sha1: fc8c92df1f57791492788924f54f1b5fb3db8a9a
+  sha256: 70596c950b0b5e99ef7942a5cfbd07dc3e76475b3332be3400a0741a7eb77458
 - type: file
   dest: .m2/repository/org/eclipse/sisu/sisu-inject/0.9.0.M3
   url: https://repo.maven.apache.org/maven2/org/eclipse/sisu/sisu-inject/0.9.0.M3/sisu-inject-0.9.0.M3.pom
-  sha1: 5f3032adbe02ebed10174e982dc334db0542561f
+  sha256: 2e436563d5caea351bce5f0863ebc6376405cb65a6f664b255faad9e72e3b854
 - type: file
   dest: .m2/repository/org/freemarker/freemarker/2.3.33
   url: https://repo.maven.apache.org/maven2/org/freemarker/freemarker/2.3.33/freemarker-2.3.33.jar
-  sha1: fecaeb606993fc9fd0f95fe5a644048a69c39474
+  sha256: ab829182363e747a1530a368436242f4cca7ff309dd29bfca638a1fdc7b6771d
 - type: file
   dest: .m2/repository/org/freemarker/freemarker/2.3.33
   url: https://repo.maven.apache.org/maven2/org/freemarker/freemarker/2.3.33/freemarker-2.3.33.pom
-  sha1: 227c71962af157c972ec7d89b426f1dc5ed87690
+  sha256: f8d10620a17a0601e812f70faf5295d78adddb11433af472044271bc3c5e5856
 - type: file
   dest: .m2/repository/org/hamcrest/hamcrest/3.0
   url: https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest/3.0/hamcrest-3.0.jar
-  sha1: 8fd9b78a8e6a6510a078a9e30e9e86a6035cfaf7
+  sha256: 5d66b6a4a680755cb6ed7cb104fa7835ef644667586ff0737adeb977c39ecdbc
 - type: file
   dest: .m2/repository/org/hamcrest/hamcrest/3.0
   url: https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest/3.0/hamcrest-3.0.pom
-  sha1: 3c85240a040ddb51dc33d405ef0e075ec68b6796
+  sha256: 4a04a68133bf32461f47b8a53c8ee9df4ce2f49a0dad9794bce8717bee5bac31
 - type: file
   dest: .m2/repository/org/infinispan/infinispan-bom/11.0.19.Final
   url: https://repo.maven.apache.org/maven2/org/infinispan/infinispan-bom/11.0.19.Final/infinispan-bom-11.0.19.Final.pom
-  sha1: dad531993049b506f8c4c5520755c779e488da47
+  sha256: 3a606fd2b5f77fdf75acf335e5badd467c42405b11f268e73c17eb92433e5a11
 - type: file
   dest: .m2/repository/org/infinispan/infinispan-build-configuration-parent/11.0.19.Final
   url: https://repo.maven.apache.org/maven2/org/infinispan/infinispan-build-configuration-parent/11.0.19.Final/infinispan-build-configuration-parent-11.0.19.Final.pom
-  sha1: 91cfc37c0061a49c1a806b81fe8d2fc6e3efe8f3
+  sha256: 120860c56a4d77bcc1223cbae740eeb26f2f9355d49a17d5f165800ee0afaa7a
 - type: file
   dest: .m2/repository/org/iq80/snappy/snappy/0.4
   url: https://repo.maven.apache.org/maven2/org/iq80/snappy/snappy/0.4/snappy-0.4.jar
-  sha1: a42b2d92a89efd35bb14738000dabcac6bd07a8d
+  sha256: 46a0c87d504ce9d6063e1ff6e4d20738feb49d8abf85b5071a7d18df4f11bac9
 - type: file
   dest: .m2/repository/org/iq80/snappy/snappy/0.4
   url: https://repo.maven.apache.org/maven2/org/iq80/snappy/snappy/0.4/snappy-0.4.pom
-  sha1: a2a52b5dc6183010d4e3d12a520ced355607ce32
+  sha256: a709ce17111e4149d9b79a5295644e0cd5a8355aec4b2ef4c0436aba7b25d08a
 - type: file
   dest: .m2/repository/org/jboss/jboss-parent/36
   url: https://repo.maven.apache.org/maven2/org/jboss/jboss-parent/36/jboss-parent-36.pom
-  sha1: b80e66dcc3abe7b9bdfd897bbd07ba7131d5ee73
+  sha256: 000dd616298aebd21a9d5731874df083d7298424b91e037b73cbdd07ebc83e0e
 - type: file
   dest: .m2/repository/org/jetbrains/annotations/13.0
   url: https://repo.maven.apache.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0.jar
-  sha1: 919f0dfe192fb4e063e7dacadee7f8bb9a2672a9
+  sha256: ace2a10dc8e2d5fd34925ecac03e4988b2c0f851650c94b8cef49ba1bd111478
 - type: file
   dest: .m2/repository/org/jetbrains/annotations/13.0
   url: https://repo.maven.apache.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0.pom
-  sha1: fa7d3d07cc80547e2d15bf4839d3267c637c642f
+  sha256: 965aeb2bedff369819bdde1bf7a0b3b89b8247dd69c88b86375d76163bb8c397
 - type: file
   dest: .m2/repository/org/jetbrains/annotations/26.0.2
   url: https://repo.maven.apache.org/maven2/org/jetbrains/annotations/26.0.2/annotations-26.0.2.jar
-  sha1: c7ce3cdeda3d18909368dfe5977332dfad326c6d
+  sha256: 2037be378980d3ba9333e97955f3b2cde392aa124d04ca73ce2eee6657199297
 - type: file
   dest: .m2/repository/org/jetbrains/annotations/26.0.2
   url: https://repo.maven.apache.org/maven2/org/jetbrains/annotations/26.0.2/annotations-26.0.2.pom
-  sha1: f5aec4dfec9035882a40667c30e17a7b470151e8
+  sha256: 7ebeceade8dada7cb17eff3e014922c39022d2a378e3e2d2461f28f016ffc7f7
 - type: file
   dest: .m2/repository/org/jetbrains/kotlin/kotlin-reflect/1.6.10
   url: https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.6.10/kotlin-reflect-1.6.10.jar
-  sha1: 1cbe9c92c12a94eea200d23c2bbaedaf3daf5132
+  sha256: 3277ac102ae17aad10a55abec75ff5696c8d109790396434b496e75087854203
 - type: file
   dest: .m2/repository/org/jetbrains/kotlin/kotlin-reflect/1.6.10
   url: https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.6.10/kotlin-reflect-1.6.10.pom
-  sha1: 535560dfd5b3dba98f57b12f3e921c7a83d0aafe
+  sha256: 57905524274a00ae028aaccc27283f6bc5925a934a046c1cc5d06c8ee4d6d5a9
 - type: file
   dest: .m2/repository/org/jetbrains/kotlin/kotlin-stdlib/1.6.10
   url: https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.6.10/kotlin-stdlib-1.6.10.pom
-  sha1: fe039b18132328e8e48284f6655c3edcdefab007
+  sha256: 3b08709ea4bae3669d9a29b9e007a8550b10c1516c10a8f6dbe9f94ab81dc46d
 - type: file
   dest: .m2/repository/org/jetbrains/kotlin/kotlin-stdlib/2.0.20
   url: https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/2.0.20/kotlin-stdlib-2.0.20.pom
-  sha1: 1f331b5e2ac02f11de3e248564ffedf60a8452b3
+  sha256: 0aee962091e7dd0288cc3ca4cf4a928c562071460211bf8f4179009306e619fe
 - type: file
   dest: .m2/repository/org/jetbrains/kotlin/kotlin-stdlib/2.1.10
   url: https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/2.1.10/kotlin-stdlib-2.1.10.jar
-  sha1: d3028429e7151d7a7c1a0d63a4f60eac86a87b91
+  sha256: 5f2ac1ca8dc8b37a3f4314e716d36969ebf0227a75181d32699d0a8f645b1c21
 - type: file
   dest: .m2/repository/org/jetbrains/kotlin/kotlin-stdlib/2.1.10
   url: https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/2.1.10/kotlin-stdlib-2.1.10.pom
-  sha1: 2dacdd6fa22033bd2beef9d3292d8f0d84a2e132
+  sha256: 4922121d3f0bc60ce407f372de42d02a0b7e94e75d0c3d1508b6835721f249ef
 - type: file
   dest: .m2/repository/org/jetbrains/kotlin/kotlin-stdlib-common/1.6.10
   url: https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1.6.10/kotlin-stdlib-common-1.6.10.pom
-  sha1: d3974425e52440bfe098563c1f10f5712471453d
+  sha256: f75af217cdd8dd9e07b1e0e018084a32092a091a390b73feaa657ec44e5cf094
 - type: file
   dest: .m2/repository/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.6.10
   url: https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.6.10/kotlin-stdlib-jdk7-1.6.10.jar
-  sha1: e1c380673654a089c4f0c9f83d0ddfdc1efdb498
+  sha256: 2aedcdc6b69b33bdf5cc235bcea88e7cf6601146bb6bcdffdb312bbacd7be261
 - type: file
   dest: .m2/repository/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.6.10
   url: https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.6.10/kotlin-stdlib-jdk7-1.6.10.pom
-  sha1: 5da7f12df7646d63f35e8a894157143c93efceb4
+  sha256: 612211ff930f5b52c724ff763417d5aa281dd7e0325c3b35c8d18120a6a8df4d
 - type: file
   dest: .m2/repository/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.6.10
   url: https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.6.10/kotlin-stdlib-jdk8-1.6.10.jar
-  sha1: e80fe6ac3c3573a80305f5ec43f86b829e8ab53d
+  sha256: 1456d82d039ea30d8485b032901f52bbf07e7cdbe8bb1f8708ad32a8574c41ce
 - type: file
   dest: .m2/repository/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.6.10
   url: https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.6.10/kotlin-stdlib-jdk8-1.6.10.pom
-  sha1: 9ad76ce2a9e0473c5d5d4ec01add1b061beb521d
+  sha256: 43a649fa737bfb35fa4af4e6de33e2f08a5d19104d7582ea40dbcd2b63790acc
 - type: file
   dest: .m2/repository/org/jspecify/jspecify/1.0.0
   url: https://repo.maven.apache.org/maven2/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar
-  sha1: 7425a601c1c7ec76645a78d22b8c6a627edee507
+  sha256: 1fad6e6be7557781e4d33729d49ae1cdc8fdda6fe477bb0cc68ce351eafdfbab
 - type: file
   dest: .m2/repository/org/jspecify/jspecify/1.0.0
   url: https://repo.maven.apache.org/maven2/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.pom
-  sha1: fae4a252aeee8a649653b2f239067bcead8f80cb
+  sha256: cdab929a3b95211f43d2090c5e2d0dfe8465960e378bc32b35841dab324433a6
 - type: file
   dest: .m2/repository/org/junit/junit-bom/5.7.1
   url: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.7.1/junit-bom-5.7.1.pom
-  sha1: ea517dcd1a0692cf193264d3e3ef0cc1a4a7b410
+  sha256: 0b9b14a3d62106fafe8c68a717b87b87ad18685899451b753c04fa41b6857784
 - type: file
   dest: .m2/repository/org/junit/junit-bom/5.7.2
   url: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.7.2/junit-bom-5.7.2.pom
-  sha1: e8848369738c03e40af5507686216f9b8b44b6a3
+  sha256: cd14aaa869991f82021c585d570d31ff342bcba58bb44233b70193771b96487b
 - type: file
   dest: .m2/repository/org/junit/junit-bom/5.8.0-M1
   url: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.8.0-M1/junit-bom-5.8.0-M1.pom
-  sha1: 2b0372987a90d91744e3177696a904d3736050b4
+  sha256: 77144432ffc68bd98a790ab1069619d91032cfc0e4e13c08163aa03da36fd6e2
 - type: file
   dest: .m2/repository/org/junit/junit-bom/5.9.2
   url: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.9.2/junit-bom-5.9.2.pom
-  sha1: 645a08cbe455cad14d8bfb25a35d7f594c53cafd
+  sha256: 2ed07d65845131f5336a86476c9a4056b59d0b58b9815ab3679bb0f36f35f705
 - type: file
   dest: .m2/repository/org/junit/junit-bom/5.9.3
   url: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.9.3/junit-bom-5.9.3.pom
-  sha1: b1874b6a66656e4f5e4b492ab321249bcb749dc7
+  sha256: 4d0329cd9e72f2420e5ca15724cbfe6ffa6e5fd2888361516271190fdc342ed7
 - type: file
   dest: .m2/repository/org/junit/junit-bom/5.10.0
   url: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.10.0/junit-bom-5.10.0.pom
-  sha1: 1136f35a5438634393bf628f69b8ca43c8518f7c
+  sha256: e006dd8894f9fc7b75fc32bb12fe5ed8be65667d5b454f99e2e0b8c5bb8d30b3
 - type: file
   dest: .m2/repository/org/junit/junit-bom/5.10.1
   url: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.10.1/junit-bom-5.10.1.pom
-  sha1: 41a86ea51227739a5b7ca3430ae88ce44a64a42a
+  sha256: 21c4b0286f4b20069577ff4b20978a85c100ac8a46b6f1c8672fbaab337bc3f2
 - type: file
   dest: .m2/repository/org/junit/junit-bom/5.10.2
   url: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.10.2/junit-bom-5.10.2.pom
-  sha1: b25ed98a5bd08cdda60e569cf22822a760e76019
+  sha256: 169dd904a4b0f6520cffe658cc62292bfe9f3c14a989fa92120724cde43a9968
 - type: file
   dest: .m2/repository/org/junit/junit-bom/5.10.3
   url: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.10.3/junit-bom-5.10.3.pom
-  sha1: fe8295327d9e5cb3bf1641493dd1485bc714b1e4
+  sha256: 10937d44c425984cb8739225d34712e1a3145641ca93ac3f7ef186fa25f6babc
 - type: file
   dest: .m2/repository/org/junit/junit-bom/5.11.0
   url: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.11.0/junit-bom-5.11.0.pom
-  sha1: a4a8a67d5348d748a6345d6f1d08846fb2780ed9
+  sha256: e67459d4882424ac6374f40db1c8f4a2e88946b340ba072c80be932a2be4644d
 - type: file
   dest: .m2/repository/org/junit/junit-bom/5.11.1
   url: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.11.1/junit-bom-5.11.1.pom
-  sha1: 2304535116410db7d9c8293bb8d48647cfdd6148
+  sha256: c72124a9c9a79910c1858766b72c350e1a39244cbfb4b076348fbfe078281965
 - type: file
   dest: .m2/repository/org/junit/junit-bom/5.11.2
   url: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.11.2/junit-bom-5.11.2.pom
-  sha1: 648240c3caf38516ade09d6c7b1df23fd5ffb503
+  sha256: f48e88538aac145eb3ae0345a9ebd055b28f329a35dce8d1e9281325ca9b0ea2
 - type: file
   dest: .m2/repository/org/junit/junit-bom/5.11.3
   url: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.11.3/junit-bom-5.11.3.pom
-  sha1: ff35120d66bcbdd05c8b94b57b08b9d30f15c343
+  sha256: f13df2e4caf1febce567667e7c378101a0331d53d1324d6e2dfe3aecfb1f7774
 - type: file
   dest: .m2/repository/org/junit/junit-bom/5.11.4
   url: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.11.4/junit-bom-5.11.4.pom
-  sha1: c02d99183d700dae681ed4a699dfcbe3d77dc507
+  sha256: 19d4b747b204805325b6334553296f986562277a4ac1cb5e593a5e4c4f5e4115
 - type: file
   dest: .m2/repository/org/junit/junit-bom/5.12.1
   url: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.12.1/junit-bom-5.12.1.pom
-  sha1: d4bbd68fa141b078fd8a46f313faa41c54b0af78
+  sha256: 7c826bc72beddc817dad9263027f9012a0f55a377d38df89c42932a2501c2bf0
 - type: file
   dest: .m2/repository/org/junit/junit-bom/5.13.1
   url: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.13.1/junit-bom-5.13.1.pom
-  sha1: 4a2b7185be9155ef83499f1da0ef2f15e0f4fffd
+  sha256: fa68451ea830572ed43ffe51d75b6a05f7a5e665a602a51f49d6be02063a65f3
 - type: file
   dest: .m2/repository/org/junit/jupiter/junit-jupiter/5.13.1
   url: https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter/5.13.1/junit-jupiter-5.13.1.jar
-  sha1: e161de3741e97249c17c1a1e0173196e126ff873
+  sha256: ba0ba2fa755b671e4fc7d28faf0cbd692875f9d9fd10f845ed64101ec641837d
 - type: file
   dest: .m2/repository/org/junit/jupiter/junit-jupiter/5.13.1
   url: https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter/5.13.1/junit-jupiter-5.13.1.pom
-  sha1: 33407acf73daf0c53020f8f850aadaf0f6da4329
+  sha256: c03f75d43ba5fd5b5da88ea6c94f47a355c4bc6c7fd6b01c89037e8fc409ae96
 - type: file
   dest: .m2/repository/org/junit/jupiter/junit-jupiter-api/5.13.1
   url: https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-api/5.13.1/junit-jupiter-api-5.13.1.jar
-  sha1: 33ee7e4a267950257dc7da8946af0db3f73e36f4
+  sha256: 3f7bd659a2f1497f8708c55ea1337842c52a5866ee27305e337cc3211596bcea
 - type: file
   dest: .m2/repository/org/junit/jupiter/junit-jupiter-api/5.13.1
   url: https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-api/5.13.1/junit-jupiter-api-5.13.1.pom
-  sha1: 1ba03329bf571d622964a8dab6abe2501fd8b9ef
+  sha256: 0dd3963fe36000925bac06a4d2674bf3e8ed70b4de5c18ce4e0bfcc2a80a5910
 - type: file
   dest: .m2/repository/org/junit/jupiter/junit-jupiter-engine/5.13.1
   url: https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-engine/5.13.1/junit-jupiter-engine-5.13.1.jar
-  sha1: f9b875488495c154f813c92ce4f67095a14c7ca1
+  sha256: ee35256c81583210f0dc14e779087c437cae5e223b9153a2138b3b890f71cfe2
 - type: file
   dest: .m2/repository/org/junit/jupiter/junit-jupiter-engine/5.13.1
   url: https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-engine/5.13.1/junit-jupiter-engine-5.13.1.pom
-  sha1: 28eae0c8a17a1ec9c4dba195b36a2be14906e91d
+  sha256: 1aca68b4a5d01332f4b3f726cab14facd406a57a8c64270a0734d101a9ce89f9
 - type: file
   dest: .m2/repository/org/junit/jupiter/junit-jupiter-params/5.13.1
   url: https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-params/5.13.1/junit-jupiter-params-5.13.1.jar
-  sha1: 190caf10c51c9c22fe835fa9961c80b386a801f6
+  sha256: 8b6ea38081803ba0ff3e7d4cedce2d41e0920e5fe2840a9dba523722829e058e
 - type: file
   dest: .m2/repository/org/junit/jupiter/junit-jupiter-params/5.13.1
   url: https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-params/5.13.1/junit-jupiter-params-5.13.1.pom
-  sha1: 5b27747afb7d5835d467987dc217df2c8589db39
+  sha256: a122a214c68e6c5768ab8139ca5b3f7412bd9e23007e07817628761fb6a007de
 - type: file
   dest: .m2/repository/org/junit/platform/junit-platform-commons/1.13.1
   url: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/1.13.1/junit-platform-commons-1.13.1.jar
-  sha1: 44a365b1bd727696717c01a2a44b8705fd52935e
+  sha256: 883d4f23d774976e7835e0695340963ed01f6c7796321e227a932ee36135887e
 - type: file
   dest: .m2/repository/org/junit/platform/junit-platform-commons/1.13.1
   url: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/1.13.1/junit-platform-commons-1.13.1.pom
-  sha1: 83ebe03ba077ccb2accfd9f902bbb4229dd46103
+  sha256: 9ff1c3b42a308bfb46a10c56faf57d4cd9a5822850a2a5214f4a5f0c6cb43ecf
 - type: file
   dest: .m2/repository/org/junit/platform/junit-platform-engine/1.13.1
   url: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-engine/1.13.1/junit-platform-engine-1.13.1.jar
-  sha1: 15a28065d991d076ae59f2406e7b8a4a9db655b7
+  sha256: 0863112f8509429b7c6c8cc1ff4619f4af450a0851b0fd95fde560cc7b9cd17e
 - type: file
   dest: .m2/repository/org/junit/platform/junit-platform-engine/1.13.1
   url: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-engine/1.13.1/junit-platform-engine-1.13.1.pom
-  sha1: 102211b746dc7e99f9044d331ede2498854b6250
+  sha256: c4a40688bd6576a30124862f294ed26015e949e8c335304bc0ce8d328aad3f0f
 - type: file
   dest: .m2/repository/org/mockito/mockito-bom/4.11.0
   url: https://repo.maven.apache.org/maven2/org/mockito/mockito-bom/4.11.0/mockito-bom-4.11.0.pom
-  sha1: 001c271051b650e8dd5ae2c9726ee5953887030d
+  sha256: d8531a746c988f7f68ed5f188cdea945006aea993ec5df9e524e0d27d61491da
 - type: file
   dest: .m2/repository/org/mockito/mockito-core/5.18.0
   url: https://repo.maven.apache.org/maven2/org/mockito/mockito-core/5.18.0/mockito-core-5.18.0.jar
-  sha1: ab47dbbf954ffa2501f29000600742098617272d
+  sha256: a3d4e40f7fe66016fe42c00de4e343777d74132afc85018e0f03ac6334a60f29
 - type: file
   dest: .m2/repository/org/mockito/mockito-core/5.18.0
   url: https://repo.maven.apache.org/maven2/org/mockito/mockito-core/5.18.0/mockito-core-5.18.0.pom
-  sha1: 547e4dc78c8347084be759348a49f54d9b5e7c0f
+  sha256: 70265634609a1555373033391edfeb879029974120a712fe0d9ad80ba248efdd
 - type: file
   dest: .m2/repository/org/nuiton/mavenpom/3.4.4
   url: https://repo.maven.apache.org/maven2/org/nuiton/mavenpom/3.4.4/mavenpom-3.4.4.pom
-  sha1: 59f10eb1c02e840b063fa3a641cc5b63222020a4
+  sha256: a138f0218a0b3d261cc08de0a688901207310f83b4221ee139b34897f3e32f49
 - type: file
   dest: .m2/repository/org/nuiton/mavenpom4redmine/3.4.4
   url: https://repo.maven.apache.org/maven2/org/nuiton/mavenpom4redmine/3.4.4/mavenpom4redmine-3.4.4.pom
-  sha1: 8c3bf1c36067dc131a6e08ad22d0d8ecc7a27366
+  sha256: a6ebddfc1c17329878d260192f753d872848511ecd313231e8859725ca258dc6
 - type: file
   dest: .m2/repository/org/nuiton/mavenpom4redmineAndCentral/3.4.4
   url: https://repo.maven.apache.org/maven2/org/nuiton/mavenpom4redmineAndCentral/3.4.4/mavenpom4redmineAndCentral-3.4.4.pom
-  sha1: b88795dcba968a44f13f90b1e3a17faa16468c7b
+  sha256: f528966f11be1e5f0f8583937b5d645753e9c2cb51e8fcd7fd4e7c8970cf96a5
 - type: file
   dest: .m2/repository/org/nuiton/processor/1.3
   url: https://repo.maven.apache.org/maven2/org/nuiton/processor/1.3/processor-1.3.pom
-  sha1: 8ca2b4baa24d057da323ffa80aa058c0e6423f75
+  sha256: a5b2ddec87de81e533749dc29712d8d612a5e145594c7fe3eb63dd6bc3b2b04b
 - type: file
   dest: .m2/repository/org/nuiton/processor/nuiton-processor/1.3
   url: https://repo.maven.apache.org/maven2/org/nuiton/processor/nuiton-processor/1.3/nuiton-processor-1.3.jar
-  sha1: 4a3d1fdd91963c25643dbb09d3f4b0e096e968dd
+  sha256: 94e6807e8eaed7396976254372fbbb5d64d21a2440f062ab8229900a0207161e
 - type: file
   dest: .m2/repository/org/nuiton/processor/nuiton-processor/1.3
   url: https://repo.maven.apache.org/maven2/org/nuiton/processor/nuiton-processor/1.3/nuiton-processor-1.3.pom
-  sha1: 5087b1a97ba07f47c73e215d07c81e54b3da0bf6
+  sha256: 804c11c30a4649a1966262ebac341fb9ca49546684cb26c65b669bcbb3b947aa
 - type: file
   dest: .m2/repository/org/objenesis/objenesis/3.3
   url: https://repo.maven.apache.org/maven2/org/objenesis/objenesis/3.3/objenesis-3.3.jar
-  sha1: 1049c09f1de4331e8193e579448d0916d75b7631
+  sha256: 02dfd0b0439a5591e35b708ed2f5474eb0948f53abf74637e959b8e4ef69bfeb
 - type: file
   dest: .m2/repository/org/objenesis/objenesis/3.3
   url: https://repo.maven.apache.org/maven2/org/objenesis/objenesis/3.3/objenesis-3.3.pom
-  sha1: 8da1208285232e541d0bbb869bbe66af6ec6abb4
+  sha256: ba0c40da2669a048b6e24ef7066a471f0fbcbfcc509e6a3e856ca4ddfa614ad3
 - type: file
   dest: .m2/repository/org/objenesis/objenesis-parent/3.3
   url: https://repo.maven.apache.org/maven2/org/objenesis/objenesis-parent/3.3/objenesis-parent-3.3.pom
-  sha1: 60b46fea1dc4cb9c3123f8c366f8b33d0c774fa3
+  sha256: 305c384aa2f1e1c7fe53a96da41c3ec35243b97d428d24a8f779818cc10be4ff
 - type: file
   dest: .m2/repository/org/odftoolkit/odfdom-java/0.9.0
   url: https://repo.maven.apache.org/maven2/org/odftoolkit/odfdom-java/0.9.0/odfdom-java-0.9.0.jar
-  sha1: 0be0b9ec78b45a8134ad5004d6dc7e6ab84133dc
+  sha256: d78ca5cdc97c2bbf03d78be85b9c8e0595b444d0ad71193934586fb3fee20ff8
 - type: file
   dest: .m2/repository/org/odftoolkit/odfdom-java/0.9.0
   url: https://repo.maven.apache.org/maven2/org/odftoolkit/odfdom-java/0.9.0/odfdom-java-0.9.0.pom
-  sha1: 9e2d72a7bc6157a5e316b48f801e0bcd2217853e
+  sha256: 60d841b563fccdda9fc607f70206f0c35f81ad5ce251ff79c8911bb3f7771dc0
 - type: file
   dest: .m2/repository/org/odftoolkit/odftoolkit/0.9.0
   url: https://repo.maven.apache.org/maven2/org/odftoolkit/odftoolkit/0.9.0/odftoolkit-0.9.0.pom
-  sha1: b03e94b433ea9ee3ff01dae0e977a80e29ecd7aa
+  sha256: b385c5e195468b731daae18752fa1903aa64152f4f36ccdd3d6eb4711e5ba3b2
 - type: file
   dest: .m2/repository/org/openjfx/javafx/14
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx/14/javafx-14.pom
-  sha1: 731669952fbae02b5b084cdfe38c40d716cd79f7
+  sha256: 2f6d85795161871a9d1286be9e2b8ec8f0dfc691fd6946f5cda4ef6fcb321c77
 - type: file
   dest: .m2/repository/org/openjfx/javafx/24.0.1
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx/24.0.1/javafx-24.0.1.pom
-  sha1: b6004be56de3b2a5ea7e5f67c8c87529d16ca3ad
+  sha256: fa56aa6072183b6f4b92491d8b41f321121eaad56a1fd4053e0e89dcaaabf197
 - type: file
   dest: .m2/repository/org/openjfx/javafx-base/14
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-base/14/javafx-base-14.pom
-  sha1: b88958ad83244f1e4af4db7cbc13c5e98b4c473a
+  sha256: 30e566fd7171dc271b3f84f9e4246ee6edec97266db4d3445af89bd64eb55de2
 - type: file
   dest: .m2/repository/org/openjfx/javafx-base/24.0.1
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-base/24.0.1/javafx-base-24.0.1.jar
-  sha1: 6748f643f79aa54922ada5c759f5a6d04d7a2ff4
+  sha256: c07204453236b8a7ca5babeecb1e213cd68b6daf10adfaccf12077acfda7a4df
 - type: file
   dest: .m2/repository/org/openjfx/javafx-base/24.0.1
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-base/24.0.1/javafx-base-24.0.1.pom
-  sha1: 7dbe6493659767f888cd4965e398a0b80d0c34f9
+  sha256: 0553b523bad69dff1a8ed9c1be81945162d5b39ba65ee12855d844a4e9a4d6b2
 - type: file
   dest: .m2/repository/org/openjfx/javafx-base/24.0.1
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-base/24.0.1/javafx-base-24.0.1-linux.jar
-  sha1: 1eb0dd4c9b54075b121b2246c41e2ff767b81768
+  sha256: 3b0e669058796a496757bb17d14e5d97a1b412ca5c1b3f1e0159f6e5d8ee23db
 - type: file
   dest: .m2/repository/org/openjfx/javafx-controls/24.0.1
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-controls/24.0.1/javafx-controls-24.0.1.jar
-  sha1: adc9707040d23e968aeee461b0c9d43a8c70d015
+  sha256: 2aab06a2fc0e19404380752fc5fca43e4978a83e5073c7424954a3f79d0bba29
 - type: file
   dest: .m2/repository/org/openjfx/javafx-controls/24.0.1
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-controls/24.0.1/javafx-controls-24.0.1.pom
-  sha1: b290bb688e1a39779ccad7f6d7393cc0000549a6
+  sha256: 409db8a93d5c42cf7c64059aba57250f094a3071d3a561b01ac053f125e710e2
 - type: file
   dest: .m2/repository/org/openjfx/javafx-controls/24.0.1
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-controls/24.0.1/javafx-controls-24.0.1-linux.jar
-  sha1: 8946a980ee0077bd28752db645155fb292931d6e
+  sha256: 699bce2d936091ed00f17b7fb4f28c4f09a4eb5d38005d1a64dd3105d8d72d37
 - type: file
   dest: .m2/repository/org/openjfx/javafx-fxml/24.0.1
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-fxml/24.0.1/javafx-fxml-24.0.1.jar
-  sha1: 291adbde46bc4c6fbd98ab1aa014d2ee3822046c
+  sha256: f86862282010cf2fbd5486927abbcef76765022ebe6e19080c7432484ed4441f
 - type: file
   dest: .m2/repository/org/openjfx/javafx-fxml/24.0.1
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-fxml/24.0.1/javafx-fxml-24.0.1.pom
-  sha1: 1236f6d372f4a8e306e3ac0d1d02a6a8d993ed0a
+  sha256: 71a7061b711f2d20f8113095af5036701e362a2f5623a1ca16f021662656b9cd
 - type: file
   dest: .m2/repository/org/openjfx/javafx-fxml/24.0.1
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-fxml/24.0.1/javafx-fxml-24.0.1-linux.jar
-  sha1: f9eb3b46f2d361a9f8bb24c0db4c56e0ca7d1c20
+  sha256: a88c7b44e524b3cfa5a921f787a3abb89c82761226dc2f2743e5e79718b2fa13
 - type: file
   dest: .m2/repository/org/openjfx/javafx-graphics/24.0.1
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-graphics/24.0.1/javafx-graphics-24.0.1.jar
-  sha1: 2f4e3f0b616c31a4886fbd12f43bb8c2244e5e48
+  sha256: 211ee0c993e150cc9943f54d4cc3968dea7e59bbc4d6318834c5bb92ae1ab9a3
 - type: file
   dest: .m2/repository/org/openjfx/javafx-graphics/24.0.1
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-graphics/24.0.1/javafx-graphics-24.0.1.pom
-  sha1: c1f86c8517bb36a95188bdae07a80c278776e0cc
+  sha256: ac6d0cfa73ddbf7890dbe9ec586d0591b1f5b42c034e6dac4a8e0f06ff69a2fc
 - type: file
   dest: .m2/repository/org/openjfx/javafx-graphics/24.0.1
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-graphics/24.0.1/javafx-graphics-24.0.1-linux.jar
-  sha1: c0b9013d797e001b364baaa14cbe988b2dea28bf
+  sha256: e6f489b9eb0be06d06b307df61fdf0bd4d9e4a66b18c9d1c53ce600e00cc66eb
 - type: file
   dest: .m2/repository/org/openjfx/javafx-swing/24.0.1
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-swing/24.0.1/javafx-swing-24.0.1.jar
-  sha1: 5a3a586a4febde4d5826c103417b168dfeab4629
+  sha256: 8947c6ea6fd5dbc103a77c82fbb32d7c2714aab81c1ebe91d64130ec69b5bd11
 - type: file
   dest: .m2/repository/org/openjfx/javafx-swing/24.0.1
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-swing/24.0.1/javafx-swing-24.0.1.pom
-  sha1: cacf7172b313abcee9146236b3d9992e90f95acd
+  sha256: 106c76819247c7a8f9f86558b050d379538f76f222ef71c423ded92f25fc7a81
 - type: file
   dest: .m2/repository/org/openjfx/javafx-swing/24.0.1
   url: https://repo.maven.apache.org/maven2/org/openjfx/javafx-swing/24.0.1/javafx-swing-24.0.1-linux.jar
-  sha1: 568a7d38db8833884a96ccec96b90e1836090707
+  sha256: 0c9c304250b72414653bcbda145225342351e9183046fcdbc139893ba9635edd
 - type: file
   dest: .m2/repository/org/opentest4j/opentest4j/1.3.0
   url: https://repo.maven.apache.org/maven2/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar
-  sha1: 152ea56b3a72f655d4fd677fc0ef2596c3dd5e6e
+  sha256: 48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b
 - type: file
   dest: .m2/repository/org/opentest4j/opentest4j/1.3.0
   url: https://repo.maven.apache.org/maven2/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.pom
-  sha1: 73f3c942f86fd30bcf1759e2f9db6e9cc0e59c32
+  sha256: 9bf7cffc410f3e8372c2522578df9ca56d9d43bd937e30948706c232a943b355
 - type: file
   dest: .m2/repository/org/osgi/org.osgi.core/6.0.0
   url: https://repo.maven.apache.org/maven2/org/osgi/org.osgi.core/6.0.0/org.osgi.core-6.0.0.jar
-  sha1: 0c49acdc9ac62cf69ee49cb6f1905b4fdb79ea5c
+  sha256: 1c1bb435eb34cbf1f743653da38f604d45d53fbc95979053768cd3fc293cb931
 - type: file
   dest: .m2/repository/org/osgi/org.osgi.core/6.0.0
   url: https://repo.maven.apache.org/maven2/org/osgi/org.osgi.core/6.0.0/org.osgi.core-6.0.0.pom
-  sha1: 5a9c1b8324244e2fc7a6b4ef429755d0912acde3
+  sha256: 42a22743fb32df6543536f78add4fcfd2557c8af5d0bf0aff5ba9d7491cde350
 - type: file
   dest: .m2/repository/org/ow2/asm/asm/9.7
   url: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/9.7/asm-9.7.jar
-  sha1: 073d7b3086e14beb604ced229c302feff6449723
+  sha256: adf46d5e34940bdf148ecdd26a9ee8eea94496a72034ff7141066b3eea5c4e9d
 - type: file
   dest: .m2/repository/org/ow2/asm/asm/9.7
   url: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/9.7/asm-9.7.pom
-  sha1: e2568079bd69f0fdf35fe2d9e7cd9b16db8eff94
+  sha256: de00115f1d84f3a0b2ee3a4b6f6192d066f86d185d67b9d1522f2c80feac5f00
 - type: file
   dest: .m2/repository/org/ow2/asm/asm/9.7.1
   url: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/9.7.1/asm-9.7.1.jar
-  sha1: f0ed132a49244b042cd0e15702ab9f2ce3cc8436
+  sha256: 8cadd43ac5eb6d09de05faecca38b917a040bb9139c7edeb4cc81c740b713281
 - type: file
   dest: .m2/repository/org/ow2/asm/asm/9.7.1
   url: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/9.7.1/asm-9.7.1.pom
-  sha1: 381a4b6892969305d88ee13c53e88eabff82d382
+  sha256: 7229b03b30a73ee91008072d9e4569a51d8547fae8c50f527841aef4c1b0baa8
 - type: file
   dest: .m2/repository/org/ow2/asm/asm-bom/9.7.1
   url: https://repo.maven.apache.org/maven2/org/ow2/asm/asm-bom/9.7.1/asm-bom-9.7.1.pom
-  sha1: f8058d97db33c5aff1e007de866555776730fb3f
+  sha256: a8d302ca91746f8ea0ad9071f62ff3a0dabd3afe61da14cc80c1c875cf618b42
 - type: file
   dest: .m2/repository/org/ow2/ow2/1.5.1
   url: https://repo.maven.apache.org/maven2/org/ow2/ow2/1.5.1/ow2-1.5.1.pom
-  sha1: bda66fa5f1b68fa7d2de3d569bdc8508b2af82d4
+  sha256: 321ddbb7ee6fe4f53dea6b4cd6db74154d6bfa42391c1f763b361b9f485acf05
 - type: file
   dest: .m2/repository/org/purejava/kdewallet/1.4.0
   url: https://repo.maven.apache.org/maven2/org/purejava/kdewallet/1.4.0/kdewallet-1.4.0.jar
-  sha1: bd7c21dc345681bf45b908c75f2acc03f1019805
+  sha256: 49f9c72262be999b9ad322bfeaade5f7acf1d425d28e7f2698e5d5886996fd00
 - type: file
   dest: .m2/repository/org/purejava/kdewallet/1.4.0
   url: https://repo.maven.apache.org/maven2/org/purejava/kdewallet/1.4.0/kdewallet-1.4.0.pom
-  sha1: 5e1fa1e4037f9982bb1cdbe18afff501a9753a98
+  sha256: 2a792bf438b614f97af3a519add87a5bdd01d401ae53e5767d0bf538f272e710
 - type: file
   dest: .m2/repository/org/purejava/libappindicator-gtk3-java-minimal/1.4.2
   url: https://repo.maven.apache.org/maven2/org/purejava/libappindicator-gtk3-java-minimal/1.4.2/libappindicator-gtk3-java-minimal-1.4.2.jar
-  sha1: 09af2819accb7e7ed60bb6aa1aace859b28d48d3
+  sha256: d8fff74b0ce94cb99f15f2b099addc37f7d02076c66bb9c361cd2ae25f37db75
 - type: file
   dest: .m2/repository/org/purejava/libappindicator-gtk3-java-minimal/1.4.2
   url: https://repo.maven.apache.org/maven2/org/purejava/libappindicator-gtk3-java-minimal/1.4.2/libappindicator-gtk3-java-minimal-1.4.2.pom
-  sha1: e67399d9ca9b240748ae40039bb4af82c0caa0d1
+  sha256: 1bcd0aede4b1494eac8e75cc14b4be989c0c7fc69ff106cd0daee03c43486d55
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-api/1.7.5
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.5/slf4j-api-1.7.5.pom
-  sha1: 8bef62de94ecb16f574fadc01dcd3127ddb1a4da
+  sha256: afaf8e74019b230d3f56fdd7c93fb1070c0dca34f3d2d5ab5dea9fc616bd5ca4
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-api/1.7.30
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.30/slf4j-api-1.7.30.pom
-  sha1: 02013960e5ee7f712d8fa6f2e618a6ff2e8d98a9
+  sha256: 7e0747751e9b67e19dcb5206f04ea22cc03d250c422426402eadd03513f2c314
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-api/1.7.36
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.jar
-  sha1: 6c62681a2f655b49963a5983b8b0950a6120ae14
+  sha256: d3ef575e3e4979678dc01bf1dcce51021493b4d11fb7f1be8ad982877c16a1c0
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-api/1.7.36
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.pom
-  sha1: 749f6995b1d6591a417ca4fd19cdbddabae16fd1
+  sha256: fb046a9c229437928bb11c2d27c8b5d773eb8a25e60cbd253d985210dedc2684
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-api/2.0.7
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/2.0.7/slf4j-api-2.0.7.pom
-  sha1: facf002401dbff2065d4257690651e3fa775e3f4
+  sha256: 2d403ccf0e0a02d5c1a8667b0e2a33c8dfc6038ab287b9671dd681c205267981
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-api/2.0.9
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/2.0.9/slf4j-api-2.0.9.pom
-  sha1: 96a47b716e8241bca75562533e3a9fbb7ffbefb9
+  sha256: 9c3a654f9d0aa1a34b3178ebe53a89c76792e1d81fc1e9739cbe9b1610523385
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-api/2.0.11
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/2.0.11/slf4j-api-2.0.11.pom
-  sha1: b98eed93875ae8db0bfa7e22cb935a3353fecb1a
+  sha256: 3784b0ed363649fafd6d99bf2ac7230f9efa81c81f5ce7edb473e2b615d90fba
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-api/2.0.13
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/2.0.13/slf4j-api-2.0.13.pom
-  sha1: cfe027e08f55e8e5b45f84cbabb4e74e8cd915ec
+  sha256: 51805cfda80ca2ac82041b906d9865d39e9823e358a0eeb62379dfed475c1571
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-api/2.0.16
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/2.0.16/slf4j-api-2.0.16.pom
-  sha1: 921407ed2b847734f2601db035850cc2473f6453
+  sha256: b1a00f5b1c4dbe62b805d65d23911a6f77063889d7cb1e86fe8389d6190473f7
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-api/2.0.17
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/2.0.17/slf4j-api-2.0.17.jar
-  sha1: d9e58ac9c7779ba3bf8142aff6c830617a7fe60f
+  sha256: 7b751d952061954d5abfed7181c1f645d336091b679891591d63329c622eb832
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-api/2.0.17
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/2.0.17/slf4j-api-2.0.17.pom
-  sha1: 0570964f8e6716b09c354c6e334ba1a092464d85
+  sha256: 150c40287f7cecdc21b9380caac98e928c4f33c023db6b348df1c5ac977026bf
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-bom/2.0.9
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-bom/2.0.9/slf4j-bom-2.0.9.pom
-  sha1: 54c55d4b55c9f82d34434fe6a36e8c6b5671588a
+  sha256: eaef4584807d812c6a0b6cf839d5e47f50c754327719b9ce081e271d15da6243
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-bom/2.0.11
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-bom/2.0.11/slf4j-bom-2.0.11.pom
-  sha1: ab12ac4635b0798eefc3dcd1a70390e98c8eafb9
+  sha256: ef0cbe21dabf74c7d7a47cb7c95aca3e6646aae8ff4998816f48e0c0ba388711
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-bom/2.0.13
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-bom/2.0.13/slf4j-bom-2.0.13.pom
-  sha1: 7154be9a411f51d833e40a654ec8bf738aaa394a
+  sha256: 7af272d7a738e2b98763791ffdd896040e8beb298a88fd606214407976cd310a
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-bom/2.0.16
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-bom/2.0.16/slf4j-bom-2.0.16.pom
-  sha1: 4e5740a21ebbd1ef8187340d92ac1f6e2c654b62
+  sha256: 0566048ec825cdf28758620af64d9e14ae38a9cd8748dd6fafa6df4a4194c279
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-bom/2.0.17
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-bom/2.0.17/slf4j-bom-2.0.17.pom
-  sha1: abbc25a81a3bc8ccacdbd9150224250e4a66542a
+  sha256: f78d27b642b4b886eb839fc102b5cd9fe7f30f37599ffe68185be4e1609031e9
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-log4j12/1.6.4
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-log4j12/1.6.4/slf4j-log4j12-1.6.4.pom
-  sha1: ab93dfaa2fb9619d91fb31a64bb65802b56ed0fb
+  sha256: c4d940168da4b9f23afc4bbd7193eba099732a1839f5047b6ad9206e1746b765
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-parent/1.6.4
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/1.6.4/slf4j-parent-1.6.4.pom
-  sha1: 50c385c4c80416a4159ff9977d576cbac9e27217
+  sha256: 76a062532f0a2503884f33ce557eae3cae2f2d38fd8db0c43e3a70405606cc85
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-parent/1.7.5
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/1.7.5/slf4j-parent-1.7.5.pom
-  sha1: 2955681f952b108824dfb16ca366f36f3cef7861
+  sha256: c43bc5a022dbfd9de82be232dffe46208cbc7de12c14385b5da824e331e535bb
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-parent/1.7.30
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/1.7.30/slf4j-parent-1.7.30.pom
-  sha1: d3cf0e0cdb58d3c6f8a08c21e55894422fd725b9
+  sha256: 11647956e48a0c5bfb3ac33f6da7e83f341002b6857efd335a505b687be34b75
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-parent/1.7.36
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/1.7.36/slf4j-parent-1.7.36.pom
-  sha1: 5ee2b2ff107aa21d6e6c8b1d38ab28d02b5bf62e
+  sha256: bb388d37fbcdd3cde64c3cede21838693218dc451f04040c5df360a78ed7e812
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-parent/2.0.7
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/2.0.7/slf4j-parent-2.0.7.pom
-  sha1: 3f97e066227cc2353d212b8c43440b0bf4c033f3
+  sha256: c182bb36cd3af1c93c1603cdfefe7889157db30ba8b584f4a44535fcd22e45e7
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-parent/2.0.9
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/2.0.9/slf4j-parent-2.0.9.pom
-  sha1: fa1b5ef4b7f48daf822d408eebd3319fa6254c0f
+  sha256: c307f0424141f1c500ae5cf0d3868e4866cb219ed5e399b66c5a07c61ea21fd5
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-parent/2.0.11
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/2.0.11/slf4j-parent-2.0.11.pom
-  sha1: 84e06a898a0870120c0d2052e2901ef2927e7c37
+  sha256: 32bee1cc0e0c3fe798c414e672d8fab892f13e9619468eb14f6027bf0e245571
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-parent/2.0.13
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/2.0.13/slf4j-parent-2.0.13.pom
-  sha1: 47cc245b4e806907ef2612563e4c124c15f99a44
+  sha256: 67facfd51f06935cea85615a04775d70d80bfd03ad0f37670351f920ed0bb58a
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-parent/2.0.16
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/2.0.16/slf4j-parent-2.0.16.pom
-  sha1: dcfa3309fdfcea2baf81d70a1d47172baf24a334
+  sha256: 09a0b4cc814d7274616c9b16d4c0fd9aaf1ecc813334de5131e547271b1982e5
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-parent/2.0.17
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/2.0.17/slf4j-parent-2.0.17.pom
-  sha1: 641edf481a624909e4da7d07343055d46aba0b77
+  sha256: 95cd71e852dfdb29126e58b7b939d57ec2b2e6024391852e0b545dee082bbf3b
 - type: file
   dest: .m2/repository/org/sonatype/forge/forge-parent/5
   url: https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/5/forge-parent-5.pom
-  sha1: a557514263bbd4a6daef8f125ab80e78413292d3
+  sha256: e56188aa8ce51278006aa90bc7e0f304a81e2f1219f462e7d21f262535cd2795
 - type: file
   dest: .m2/repository/org/sonatype/forge/forge-parent/6
   url: https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/6/forge-parent-6.pom
-  sha1: 8726e91194a5442e05472854652602a3b599f27d
+  sha256: 9c5f7cd5226ac8c3798cb1f800c031f7dedc1606dc50dc29567877c8224459a7
 - type: file
   dest: .m2/repository/org/sonatype/oss/oss-parent/7
   url: https://repo.maven.apache.org/maven2/org/sonatype/oss/oss-parent/7/oss-parent-7.pom
-  sha1: 46b8a785b60a2767095b8611613b58577e96d4c9
+  sha256: b51f8867c92b6a722499557fc3a1fdea77bdf9ef574722fe90ce436a29559454
 - type: file
   dest: .m2/repository/org/sonatype/oss/oss-parent/9
   url: https://repo.maven.apache.org/maven2/org/sonatype/oss/oss-parent/9/oss-parent-9.pom
-  sha1: e5cdc4d23b86d79c436f16fed20853284e868f65
+  sha256: fb40265f982548212ff82e362e59732b2187ec6f0d80182885c14ef1f982827a
 - type: file
   dest: .m2/repository/org/sonatype/plexus/plexus-build-api/0.0.7
   url: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/0.0.7/plexus-build-api-0.0.7.jar
-  sha1: e6ba5cd4bfd8de00235af936e7f63eb24ed436e6
+  sha256: 934171640fbd3d2495c50b79b0d9adb11e2c83e65bad157df8fe34bcac0ff798
 - type: file
   dest: .m2/repository/org/sonatype/plexus/plexus-build-api/0.0.7
   url: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/0.0.7/plexus-build-api-0.0.7.pom
-  sha1: 1e4a1b9e61ff446213473bbd1f3d970c0d1c4d62
+  sha256: e067317a47ed9e84b2ba85a76d3cf72980e2b0dc873a90b9cbfe74fe80c37c17
 - type: file
   dest: .m2/repository/org/sonatype/sisu/inject/guice-bean/1.4.2
   url: https://repo.maven.apache.org/maven2/org/sonatype/sisu/inject/guice-bean/1.4.2/guice-bean-1.4.2.pom
-  sha1: 11c2c29c95aa9c9d636ac349b33b49de1190deaf
+  sha256: d2ee7efbcdc82206c69559548aef86a99add95378f03cc58b4d9696b3969c8bb
 - type: file
   dest: .m2/repository/org/sonatype/sisu/inject/guice-plexus/1.4.2
   url: https://repo.maven.apache.org/maven2/org/sonatype/sisu/inject/guice-plexus/1.4.2/guice-plexus-1.4.2.pom
-  sha1: 9b167556a64cb79acea3a8dbf6c2f580e2699d2b
+  sha256: 13a66ca6e6ad1a186076513eea822db2c3c0e460a983a0a31f4d937de336ad98
 - type: file
   dest: .m2/repository/org/sonatype/sisu/sisu-guice/2.1.7
   url: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-guice/2.1.7/sisu-guice-2.1.7.pom
-  sha1: f690b118b2c3ca4cf400a558e6d000a971fd8d98
+  sha256: 2b3f02f2d0ec3e95884f9ab415596ce627492469c2d8fd75e3fb00fb69532c44
 - type: file
   dest: .m2/repository/org/sonatype/sisu/sisu-inject/1.4.2
   url: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject/1.4.2/sisu-inject-1.4.2.pom
-  sha1: 780340415a1dc940f10ae38a7b32e84db28c95dd
+  sha256: a5991ead85259ba9f8c985d194aace3b069e14bcd8cde68fce928223714d3968
 - type: file
   dest: .m2/repository/org/sonatype/sisu/sisu-inject-bean/1.4.2
   url: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.pom
-  sha1: 8b8bd0a19ec8218bb04e27aca13658605c9d7588
+  sha256: 06d75dd6f2a0dc9ea6bf73a67491ba4790f92251c654bf4925511e5e4f48f1df
 - type: file
   dest: .m2/repository/org/sonatype/sisu/sisu-inject-plexus/1.4.2
   url: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2.pom
-  sha1: 3e27a576e375175ba275f21692d99a386d879405
+  sha256: e302200cf462cf1af9f3e870738253cdf90d7abc8279b9d3b507a5d0d3b9f289
 - type: file
   dest: .m2/repository/org/sonatype/sisu/sisu-parent/1.4.2
   url: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-parent/1.4.2/sisu-parent-1.4.2.pom
-  sha1: 11c9a4a343a22f80cfe4e9677d7b0679850e4196
+  sha256: abb04084d0885319fd0b372d77655f8feb8aa8bb091699fcd99b45798a9587d5
 - type: file
   dest: .m2/repository/org/sonatype/spice/spice-parent/15
   url: https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/15/spice-parent-15.pom
-  sha1: 3cfa1d1f3113a8137fdc7b7a67f310abbed4a22d
+  sha256: 13d15ddfe9946b8427bb7b4b081ab63962285eed0bf6fa5142aea25a46e15814
 - type: file
   dest: .m2/repository/org/springframework/spring-framework-bom/5.3.32
   url: https://repo.maven.apache.org/maven2/org/springframework/spring-framework-bom/5.3.32/spring-framework-bom-5.3.32.pom
-  sha1: 8825605fc0859103e7bd289754d257b30c80eb28
+  sha256: 825af7112e3d92ea436bb0df78c19514885f5c016d0fc60c8b24d4763a015a10
 - type: file
   dest: .m2/repository/org/springframework/spring-framework-bom/5.3.39
   url: https://repo.maven.apache.org/maven2/org/springframework/spring-framework-bom/5.3.39/spring-framework-bom-5.3.39.pom
-  sha1: 51d5e26004c5cd98c1d0bd562e0579f18e6552e8
+  sha256: f6d481093e75767cba1ac7e1db38f8f692cbe3e38744693371a75aeb21c6148b
 - type: file
   dest: .m2/repository/org/testcontainers/testcontainers-bom/1.20.3
   url: https://repo.maven.apache.org/maven2/org/testcontainers/testcontainers-bom/1.20.3/testcontainers-bom-1.20.3.pom
-  sha1: 39025d97c1169ec771789bfa8b4155b8f3b518b3
+  sha256: 0561333476c3ca2fbc014964badae7ea05e3a30b55d1a06b6df0dd89d22598fb
 - type: file
   dest: .m2/repository/org/tukaani/xz/1.9
   url: https://repo.maven.apache.org/maven2/org/tukaani/xz/1.9/xz-1.9.jar
-  sha1: 1ea4bec1a921180164852c65006d928617bd2caf
+  sha256: 211b306cfc44f8f96df3a0a3ddaf75ba8c5289eed77d60d72f889bb855f535e5
 - type: file
   dest: .m2/repository/org/tukaani/xz/1.9
   url: https://repo.maven.apache.org/maven2/org/tukaani/xz/1.9/xz-1.9.pom
-  sha1: 67a95cd14d42aa16c6cc1e7a40fba28e3ddb7521
+  sha256: 093be1b03331bce2932d6825c37e98272d7621e6a9e9fb93289a002518b8dd5a
 - type: file
   dest: .m2/repository/xerces/xercesImpl/2.12.1
   url: https://repo.maven.apache.org/maven2/xerces/xercesImpl/2.12.1/xercesImpl-2.12.1.jar
-  sha1: 3a206b25679f598a03374afd4e0410d8849b088b
+  sha256: ae0c329a3187178c8e7b0369a5346845e426062ffbb8a08fc68ced6affe6c626
 - type: file
   dest: .m2/repository/xerces/xercesImpl/2.12.1
   url: https://repo.maven.apache.org/maven2/xerces/xercesImpl/2.12.1/xercesImpl-2.12.1.pom
-  sha1: cd95a52019fc2b5be64a663781d4e92d9e6692cb
+  sha256: a70840f93c1582812c4b0c1c690a6a9a55e21e417cce59a4d56df1c8d1c230a2
 - type: file
   dest: .m2/repository/xml-apis/xml-apis/1.4.01
   url: https://repo.maven.apache.org/maven2/xml-apis/xml-apis/1.4.01/xml-apis-1.4.01.jar
-  sha1: 3789d9fada2d3d458c4ba2de349d48780f381ee3
+  sha256: a840968176645684bb01aed376e067ab39614885f9eee44abe35a5f20ebe7fad
 - type: file
   dest: .m2/repository/xml-apis/xml-apis/1.4.01
   url: https://repo.maven.apache.org/maven2/xml-apis/xml-apis/1.4.01/xml-apis-1.4.01.pom
-  sha1: 1c657bc14f11cbfcebb2ebf63eebd5cd85b08872
+  sha256: 09a82ff150ac86bfa31145e0a6afd89a02e4504785f5da112e4fae1425020e92

--- a/org.cryptomator.Cryptomator.yaml
+++ b/org.cryptomator.Cryptomator.yaml
@@ -172,5 +172,11 @@ modules:
         sha512: 330bc3e64f260c687ece19c60095d10bbe3ce2dea6cd67a1e48a972b71c341ffe79a750332918d567393b4f1eede89cd552c144ad39fadcb40d23d1ff9acb79a
       - type: file
         dest-filename: maven.tar.gz
-        url: https://dlcdn.apache.org/maven/maven-3/3.9.10/binaries/apache-maven-3.9.10-bin.tar.gz
+        url: https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.tar.gz
         sha512: 4ef617e421695192a3e9a53b3530d803baf31f4269b26f9ab6863452d833da5530a4d04ed08c36490ad0f141b55304bceed58dbf44821153d94ae9abf34d0e1b
+        x-checker-data:
+          type: anitya
+          project-id: 1894
+          stable-only: true
+          url-template: https://repo1.maven.org/maven2/org/apache/maven/apache-maven/$version/apache-maven-$version-bin.tar.gz
+          versions: {<: '4.0'}

--- a/org.cryptomator.Cryptomator.yaml
+++ b/org.cryptomator.Cryptomator.yaml
@@ -172,8 +172,8 @@ modules:
         sha512: 330bc3e64f260c687ece19c60095d10bbe3ce2dea6cd67a1e48a972b71c341ffe79a750332918d567393b4f1eede89cd552c144ad39fadcb40d23d1ff9acb79a
       - type: file
         dest-filename: maven.tar.gz
-        url: https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.tar.gz
-        sha512: 4ef617e421695192a3e9a53b3530d803baf31f4269b26f9ab6863452d833da5530a4d04ed08c36490ad0f141b55304bceed58dbf44821153d94ae9abf34d0e1b
+        url: https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.tar.gz
+        sha512: bcfe4fe305c962ace56ac7b5fc7a08b87d5abd8b7e89027ab251069faebee516b0ded8961445d6d91ec1985dfe30f8153268843c89aa392733d1a3ec956c9978
         x-checker-data:
           type: anitya
           project-id: 1894

--- a/update-maven-dependencies.sh
+++ b/update-maven-dependencies.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# update.sh - Script to update the Cryptomator Flatpak maven dependencies
+# Requires yq and natsort to be installed
+
+set -e
+
+# clean up previous builds
+rm -rf .flatpak-builder/ build/ repo
+
+# patch the yml file
+## This allows the Flatpak to access the network, which is required to update maven dependencies
+yq '(.modules[] | select(.name == "cryptomator") | .build-options.build-args) = ["--share=network"]' -i org.cryptomator.Cryptomator.yaml
+## Remove the maven dependency files from the sources list
+yq '(.modules[] | select(.name == "cryptomator") | .sources) |= map(select( . == "maven*" | not))' -i org.cryptomator.Cryptomator.yaml
+
+# Build the Flatpak package
+flatpak-builder --force-clean --install-deps-from=flathub --build-only --keep-build-dirs build org.cryptomator.Cryptomator.yaml
+
+# Update maven dependencies
+## Update arch independent dependencies
+( cd .flatpak-builder/build/*-1/.m2/repository/             \
+ && find * -type f \( -iname '*.jar' -o -iname '*.pom' \)   \
+ | grep -v 'javafx-*-linux-*.jar'                           \
+ | natsort -p                                               \
+ | xargs -rI '{}' bash -c                                   \
+ 'echo -e "- type: file\n  dest: .m2/repository/$(dirname {})\n  url: https://repo.maven.apache.org/maven2/{}\n  sha256: $(sha256sum {} | cut -c 1-64)"' \
+ ) > maven-dependencies.yaml
+
+## Update x86_64 arch dependencies
+( cd .flatpak-builder/build/*-1/.m2/repository/         \
+ && find * -type f \( -iname 'javafx-*-linux.jar' \)    \
+ | natsort -p                                           \
+ | xargs -rI '{}' bash -c                               \
+ 'echo -e "- type: file\n  dest: .m2/repository/$(dirname {})\n  url: https://repo.maven.apache.org/maven2/{}\n  sha256: $(sha256sum {} | cut -c 1-64)\n  only-arches: [x86_64]"' \
+ ) > maven-dependencies-x86_64.yaml
+
+
+## Update aarch64 arch dependencies :-P
+echo "WARNING: JavaFX AARCH64 dependencies are not updated automatically."
+echo "Please update them manually."
+
+# revert the yml file to its original state
+git checkout org.cryptomator.Cryptomator.yaml


### PR DESCRIPTION
This PR:
* updates all sha1 checksums of the maven dependencies to sha256 sums
* updates maven to 3.9.11
* adds the [flatpak external data checker](https://github.com/flathub-infra/flatpak-external-data-checker) for the Apache maven resource.